### PR TITLE
Missing center key on load, y,z being set on box collider

### DIFF
--- a/ColliderTuner.cs
+++ b/ColliderTuner.cs
@@ -535,6 +535,15 @@ public class ColliderTuner : MVRScript
                 capsuleCollider.radius = jc[$"radius{suffix}"].AsFloat;
             if (jc.HasKey($"height{suffix}"))
                 capsuleCollider.height = jc[$"height{suffix}"].AsFloat;
+
+            var center = capsuleCollider.center;
+            if (jc.HasKey($"center.x{suffix}"))
+                center.x = jc[$"center.x{suffix}"].AsFloat;
+            if (jc.HasKey($"center.y{suffix}"))
+                center.y = jc[$"center.y{suffix}"].AsFloat;
+            if (jc.HasKey($"center.z{suffix}"))
+                center.z = jc[$"center.z{suffix}"].AsFloat;
+            capsuleCollider.center = center;
         }
         else if (collider is BoxCollider)
         {
@@ -543,9 +552,9 @@ public class ColliderTuner : MVRScript
             if (jc.HasKey($"x{suffix}"))
                 size.x = jc[$"x{suffix}"].AsFloat;
             if (jc.HasKey($"y{suffix}"))
-                size.x = jc[$"y{suffix}"].AsFloat;
+                size.y = jc[$"y{suffix}"].AsFloat;
             if (jc.HasKey($"z{suffix}"))
-                size.x = jc[$"z{suffix}"].AsFloat;
+                size.z = jc[$"z{suffix}"].AsFloat;
             boxCollider.size = size;
         }
         else


### PR DESCRIPTION
Very happy, my preset works perfectly now. It was just missing the set of the center values on capsule collidors and the size X was being overwritten with the Y and Z values