### PR TITLE
Make plugin compatible with MeshColliders

### DIFF
--- a/src/EditablesList.cs
+++ b/src/EditablesList.cs
@@ -172,6 +172,7 @@ public class EditablesList
         if (collider.name.Contains("Ponytail")) return false;
         if (collider.name.StartsWith("PhysicsMeshJoint")) return false;
         if (collider.name.EndsWith("Joint")) return false;
+        if (collider is MeshCollider) return false;
         return true;
     }
 


### PR DESCRIPTION
Fix the plugin failing to load when MeshColliders (used by collidable CustomUnityAssets) were present with the Person set as their parent.