### PR TITLE
Reduce the default range of positions and offset

### DIFF
--- a/src/Models/AutoColliderModel.cs
+++ b/src/Models/AutoColliderModel.cs
@@ -231,7 +231,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
                         Component.colliderLookOffset = _colliderLookOffset = value;
                         RefreshAutoCollider();
                         SetModified();
-                    }, -0.25f, 0.25f, false)
+                    }, MakeMinOffset(Component.colliderLookOffset), MakeMaxOffset(Component.colliderLookOffset), false)
                     .WithDefault(_initialColliderLookOffset)
                 ), "Look Offset")
         );
@@ -243,7 +243,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
                         Component.colliderUpOffset = _colliderUpOffset = value;
                         RefreshAutoCollider();
                         SetModified();
-                    }, -0.25f, 0.25f, false)
+                    }, MakeMinOffset(Component.colliderUpOffset), MakeMaxOffset(Component.colliderUpOffset), false)
                     .WithDefault(_initialColliderUpOffset)
                 ), "Up Offset")
         );
@@ -255,7 +255,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
                         Component.colliderRightOffset = _colliderRightOffset = value;
                         RefreshAutoCollider();
                         SetModified();
-                    }, -0.25f, 0.25f, false)
+                    }, MakeMinOffset(Component.colliderRightOffset), MakeMaxOffset(Component.colliderRightOffset), false)
                     .WithDefault(_initialColliderRightOffset)
                 ), "Right Offset")
         );

--- a/src/Models/BoxColliderModel.cs
+++ b/src/Models/BoxColliderModel.cs
@@ -106,7 +106,7 @@ public class BoxColliderModel : ColliderModel<BoxCollider>
             Collider.center = _center = center;
             SetModified();
             SyncPreview();
-        }, -0.25f, 0.25f, false)).WithDefault(_initialCenter.x), "Center.X"));
+        }, MakeMinPosition(Collider.center.x), MakeMaxPosition(Collider.center.x), false)).WithDefault(_initialCenter.x), "Center.X"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerY", Collider.center.y, value =>
         {
@@ -115,7 +115,7 @@ public class BoxColliderModel : ColliderModel<BoxCollider>
             Collider.center = _center = center;
             SetModified();
             SyncPreview();
-        }, -0.25f, 0.25f, false)).WithDefault(_initialCenter.y), "Center.Y"));
+        }, MakeMinPosition(Collider.center.y), MakeMaxPosition(Collider.center.y), false)).WithDefault(_initialCenter.y), "Center.Y"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerZ", Collider.center.z, value =>
         {
@@ -124,6 +124,6 @@ public class BoxColliderModel : ColliderModel<BoxCollider>
             Collider.center = _center = center;
             SetModified();
             SyncPreview();
-        }, -0.25f, 0.25f, false)).WithDefault(_initialCenter.z), "Center.Z"));
+        }, MakeMinPosition(Collider.center.z), MakeMaxPosition(Collider.center.z), false)).WithDefault(_initialCenter.z), "Center.Z"));
     }
 }

--- a/src/Models/CapsuleColliderModel.cs
+++ b/src/Models/CapsuleColliderModel.cs
@@ -92,7 +92,7 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
             _gpu?.UpdateData();
             SetModified();
             SyncPreview();
-        }, -0.25f, 0.25f, false)).WithDefault(_initialCenter.x), "Center.X"));
+        }, MakeMinPosition(Collider.center.x), MakeMaxPosition(Collider.center.x), false)).WithDefault(_initialCenter.x), "Center.X"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerY", Collider.center.y, value =>
         {
@@ -102,7 +102,7 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
             _gpu?.UpdateData();
             SetModified();
             SyncPreview();
-        }, -0.25f, 0.25f, false)).WithDefault(_initialCenter.y), "Center.Y"));
+        }, MakeMinPosition(Collider.center.y), MakeMaxPosition(Collider.center.y), false)).WithDefault(_initialCenter.y), "Center.Y"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerZ", Collider.center.z, value =>
         {
@@ -112,7 +112,7 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
             _gpu?.UpdateData();
             SetModified();
             SyncPreview();
-        }, -0.25f, 0.25f, false)).WithDefault(_initialCenter.z), "Center.Z"));
+        }, MakeMinPosition(Collider.center.z), MakeMaxPosition(Collider.center.z), false)).WithDefault(_initialCenter.z), "Center.Z"));
 
         if (_gpu != null)
         {

--- a/src/Models/ModelBase.cs
+++ b/src/Models/ModelBase.cs
@@ -20,6 +20,26 @@ public abstract class ModelBase<T> where T : Component
     public bool IsDuplicate { get; set; }
     public bool Modified { get; protected set; }
 
+	public static float MakeMinOffset(float val)
+	{
+		return val - 0.025f;
+	}
+
+	public static float MakeMaxOffset(float val)
+	{
+		return val + 0.025f;
+	}
+
+	public static float MakeMinPosition(float val)
+	{
+		return val - 0.025f;
+	}
+
+	public static float MakeMaxPosition(float val)
+	{
+		return val + 0.025f;
+	}
+
     public bool Selected
     {
         get { return _selected; }

--- a/src/Models/SphereColliderModel.cs
+++ b/src/Models/SphereColliderModel.cs
@@ -73,7 +73,7 @@ public class SphereColliderModel : ColliderModel<SphereCollider>
             Collider.center = _center = center;
             SetModified();
             SyncPreview();
-        }, -0.25f, 0.25f, false)).WithDefault(_initialCenter.x), "Center.X"));
+        }, MakeMinPosition(Collider.center.x), MakeMaxPosition(Collider.center.x), false)).WithDefault(_initialCenter.x), "Center.X"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerY", Collider.center.y, value =>
         {
@@ -82,7 +82,7 @@ public class SphereColliderModel : ColliderModel<SphereCollider>
             Collider.center = _center = center;
             SetModified();
             SyncPreview();
-        }, -0.25f, 0.25f, false)).WithDefault(_initialCenter.y), "Center.Y"));
+        }, MakeMinPosition(Collider.center.y), MakeMaxPosition(Collider.center.y), false)).WithDefault(_initialCenter.y), "Center.Y"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerZ", Collider.center.z, value =>
         {
@@ -91,7 +91,7 @@ public class SphereColliderModel : ColliderModel<SphereCollider>
             Collider.center = _center = center;
             SetModified();
             SyncPreview();
-        }, -0.25f, 0.25f, false)).WithDefault(_initialCenter.z), "Center.Z"));
+        }, MakeMinPosition(Collider.center.z), MakeMaxPosition(Collider.center.z), false)).WithDefault(_initialCenter.z), "Center.Z"));
 
         if (_gpu != null)
         {


### PR DESCRIPTION
The default range for positions and offsets was always -0.25 to 0.25, which is typically much too large for the kind of movements required to fine tune colliders. I've moved all the ranges to helper functions in `ModelBase`, which return a range of -0.025 to 0.025 (ten times smaller) around the current value.