### PR TITLE
Links

### DIFF
--- a/ColliderEditor.cslist
+++ b/ColliderEditor.cslist
@@ -18,6 +18,7 @@ src\Filters.cs
 src\FloatExtensions.cs
 src\Group.cs
 src\JSONStorableExtensions.cs
+src\Links.cs
 src\MaterialHelper.cs
 src\MigrationHelper.cs
 src\NameHelper.cs

--- a/src/ColliderEditor.cs
+++ b/src/ColliderEditor.cs
@@ -42,6 +42,11 @@ public class ColliderEditor : MVRScript
         get { return _editables; }
     }
 
+    public ColliderPreviewConfig Config
+    {
+        get { return _config; }
+    }
+
     public override void Init()
     {
         try
@@ -95,6 +100,17 @@ public class ColliderEditor : MVRScript
         RegisterBool(xRayPreviews);
         var xRayPreviewsToggle = CreateToggle(xRayPreviews);
         xRayPreviewsToggle.label = "Use XRay Previews";
+
+
+        var linkColliders = new JSONStorableBool("linkColliders", ColliderPreviewConfig.DefaultLinkColliders, value =>
+        {
+            _config.LinkColliders = value;
+            SelectEditable(_selected);
+        });
+
+        RegisterBool(linkColliders);
+        var linkCollidersToggle = CreateToggle(linkColliders);
+        linkCollidersToggle.label = "Link Symmetrical Colliders";
 
         JSONStorableFloat previewOpacity = new JSONStorableFloat("previewOpacity", ColliderPreviewConfig.DefaultPreviewsOpacity, value =>
         {
@@ -302,6 +318,7 @@ public class ColliderEditor : MVRScript
             _selected2.Selected = false;
             _selected2.Shown = false;
             _selected2.UpdatePreviewFromConfig();
+            _selected2 = null;
         }
 
         if (val != null)
@@ -313,12 +330,15 @@ public class ColliderEditor : MVRScript
 
             _editablesJson.valNoCallback = val.Id;
 
-            _selected2 = _selected.Linked;
-            if (_selected2 != null)
+            if (_config.LinkColliders)
             {
-                _selected2.Selected = true;
-                _selected2.Shown = true;
-                _selected2.UpdatePreviewFromConfig();
+                _selected2 = _selected.Linked;
+                if (_selected2 != null)
+                {
+                    _selected2.Selected = true;
+                    _selected2.Shown = true;
+                    _selected2.UpdatePreviewFromConfig();
+                }
             }
         }
         else

--- a/src/ColliderEditor.cs
+++ b/src/ColliderEditor.cs
@@ -293,7 +293,13 @@ public class ColliderEditor : MVRScript
     public void SelectEditable(IModel val)
     {
         if (_selected != null) _selected.Selected = false;
-        if (_selected2 != null) _selected2.Selected = false;
+
+        if (_selected2 != null)
+        {
+            _selected2.Selected = false;
+            _selected2.Shown = false;
+            _selected2.UpdatePreviewFromConfig();
+        }
 
         if (val != null)
         {
@@ -303,7 +309,11 @@ public class ColliderEditor : MVRScript
 
             _selected2 = _selected.Linked;
             if (_selected2 != null)
+            {
                 _selected2.Selected = true;
+                _selected2.Shown = true;
+                _selected2.UpdatePreviewFromConfig();
+            }
         }
         else
         {
@@ -367,6 +377,18 @@ public class ColliderEditor : MVRScript
                 e.Shown = true;
                 e.UpdatePreviewFromConfig();
             }
+
+            if (_selected != null)
+            {
+                _selected.Shown = true;
+                _selected.UpdatePreviewFromConfig();
+            }
+
+            if (_selected2 != null)
+            {
+                _selected2.Shown = true;
+                _selected2.UpdatePreviewFromConfig();
+            }
         }
         catch (Exception e)
         {
@@ -379,8 +401,11 @@ public class ColliderEditor : MVRScript
         var previous = _editablesJson.choices.Where(x => _editables.ByUuid.ContainsKey(x)).Select(x => _editables.ByUuid[x]);
         foreach (var e in previous)
         {
-            e.Shown = false;
-            e.UpdatePreviewFromConfig();
+            if (e != _selected && e != _selected2)
+            {
+                e.Shown = false;
+                e.UpdatePreviewFromConfig();
+            }
         }
     }
 

--- a/src/ColliderEditor.cs
+++ b/src/ColliderEditor.cs
@@ -316,7 +316,7 @@ public class ColliderEditor : MVRScript
         if (_selected2 != null)
         {
             _selected2.Selected = false;
-            _selected2.Shown = false;
+            _selected2.Shown = _filteredEditables.Contains(_selected2);
             _selected2.UpdatePreviewFromConfig();
             _selected2 = null;
         }

--- a/src/ColliderEditor.cs
+++ b/src/ColliderEditor.cs
@@ -311,6 +311,9 @@ public class ColliderEditor : MVRScript
         if (_selected != null)
         {
             _selected.Selected = false;
+            _selected.Shown = _filteredEditables.Contains(_selected);
+            _selected.UpdatePreviewFromConfig();
+            _selected = null;
         }
 
         if (_selected2 != null)
@@ -404,17 +407,7 @@ public class ColliderEditor : MVRScript
                 e.UpdatePreviewFromConfig();
             }
 
-            if (_selected != null)
-            {
-                _selected.Shown = true;
-                _selected.UpdatePreviewFromConfig();
-            }
-
-            if (_selected2 != null)
-            {
-                _selected2.Shown = true;
-                _selected2.UpdatePreviewFromConfig();
-            }
+            SelectEditable(_selected);
         }
         catch (Exception e)
         {
@@ -427,12 +420,11 @@ public class ColliderEditor : MVRScript
         var previous = _editablesJson.choices.Where(x => _editables.ByUuid.ContainsKey(x)).Select(x => _editables.ByUuid[x]);
         foreach (var e in previous)
         {
-            if (e != _selected && e != _selected2)
-            {
-                e.Shown = false;
-                e.UpdatePreviewFromConfig();
-            }
+            e.Shown = false;
+            e.UpdatePreviewFromConfig();
         }
+
+        SelectEditable(_selected);
     }
 
     #region Presets

--- a/src/ColliderEditor.cs
+++ b/src/ColliderEditor.cs
@@ -32,10 +32,15 @@ public class ColliderEditor : MVRScript
     private JSONStorableStringChooser _editablesJson;
 
     private readonly ColliderPreviewConfig _config = new ColliderPreviewConfig();
-    private IModel _selected;
+    private IModel _selected, _selected2;
     private EditablesList _editables;
     private JSONClass _jsonWhenDisabled;
     private bool _restored;
+
+    public EditablesList EditablesList
+    {
+        get { return _editables; }
+    }
 
     public override void Init()
     {
@@ -109,6 +114,8 @@ public class ColliderEditor : MVRScript
             _config.SelectedPreviewsOpacity = alpha;
             if (_selected != null)
                 _selected.UpdatePreviewFromConfig();
+            if (_selected2 != null)
+                _selected2.UpdatePreviewFromConfig();
         }, 0f, 1f);
         RegisterFloat(selectedPreviewOpacity);
         CreateSlider(selectedPreviewOpacity).label = "Selected Preview Opacity";
@@ -286,11 +293,17 @@ public class ColliderEditor : MVRScript
     public void SelectEditable(IModel val)
     {
         if (_selected != null) _selected.Selected = false;
+        if (_selected2 != null) _selected2.Selected = false;
+
         if (val != null)
         {
             _selected = val;
             val.Selected = true;
             _editablesJson.valNoCallback = val.Id;
+
+            _selected2 = _selected.Linked;
+            if (_selected2 != null)
+                _selected2.Selected = true;
         }
         else
         {

--- a/src/ColliderEditor.cs
+++ b/src/ColliderEditor.cs
@@ -292,7 +292,10 @@ public class ColliderEditor : MVRScript
 
     public void SelectEditable(IModel val)
     {
-        if (_selected != null) _selected.Selected = false;
+        if (_selected != null)
+        {
+            _selected.Selected = false;
+        }
 
         if (_selected2 != null)
         {
@@ -304,7 +307,10 @@ public class ColliderEditor : MVRScript
         if (val != null)
         {
             _selected = val;
-            val.Selected = true;
+            _selected.Selected = true;
+            _selected.Shown = true;
+            _selected.UpdatePreviewFromConfig();
+
             _editablesJson.valNoCallback = val.Id;
 
             _selected2 = _selected.Linked;

--- a/src/ColliderPreviewConfig.cs
+++ b/src/ColliderPreviewConfig.cs
@@ -6,9 +6,11 @@ public class ColliderPreviewConfig
     public const bool DefaultXRayPreviews = true;
     public const float DefaultPreviewsOpacity = 0.2f;
     public const float DefaultSelectedPreviewOpacity = 0.7f;
+    public const bool DefaultLinkColliders = false;
 
     public bool PreviewsEnabled { get; set; } = DefaultPreviewsEnabled;
     public bool XRayPreviews { get; set; } = DefaultXRayPreviews;
+    public bool LinkColliders { get; set; } = DefaultLinkColliders;
     public float PreviewsOpacity {get;set;} = DefaultPreviewsOpacity.ExponentialScale(ExponentialScaleMiddle, 1f);
     public float SelectedPreviewsOpacity {get;set;} = DefaultSelectedPreviewOpacity.ExponentialScale(ExponentialScaleMiddle, 1f);
 }

--- a/src/Links.cs
+++ b/src/Links.cs
@@ -32,6 +32,13 @@ public class Links
         AddArms();
         AddHands();
         AddChest();
+        AddBreasts();
+        AddAbdomen();
+        AddHips();
+        AddGlutes();
+        AddG();
+        AddLegs();
+        AddFeet();
     }
 
     static private void Add(string a, string b)
@@ -213,5 +220,169 @@ public class Links
                 $"chest.FemaleAutoColliderschest.AutoColliderFemaleAutoColliderschestRibL{i}",
                 $"chest.FemaleAutoColliderschest.AutoColliderFemaleAutoColliderschestRibR{i}");
         }
+    }
+
+    static private void AddBreasts()
+    {
+        Add(
+            "lPectoral.FemaleAutoColliderslNipple.AutoColliderFemaleAutoColliderslNipple1",
+            "rPectoral.FemaleAutoCollidersrNipple.AutoColliderFemaleAutoCollidersrNipple1");
+
+        Add(
+            "lPectoral.FemaleAutoColliderslNipple.AutoColliderFemaleAutoColliderslNippleGPU",
+            "rPectoral.FemaleAutoCollidersrNipple.AutoColliderFemaleAutoCollidersrNippleGPU");
+
+        for (int i = 1; i <= 5; ++i)
+        {
+            Add(
+                $"lPectoral.FemaleAutoColliderslPectoral.AutoColliderFemaleAutoColliderslPectoral{i}",
+                $"rPectoral.FemaleAutoCollidersrPectoral.AutoColliderFemaleAutoCollidersrPectoral{i}");
+        }
+
+        Add(
+            "chest.lPectoral._Collider (1)",
+            "chest.rPectoral._Collider (1)");
+    }
+
+    static private void AddAbdomen()
+    {
+        Add(
+            "abdomen2.FemaleAutoCollidersabdomen2_.AutoColliderFemaleAutoCollidersabdomen2_7",
+            "abdomen2.FemaleAutoCollidersabdomen2_.AutoColliderFemaleAutoCollidersabdomen2_8");
+
+        Add(
+            "abdomen.FemaleAutoCollidersabdomen.AutoColliderFemaleAutoCollidersabdomen5",
+            "abdomen.FemaleAutoCollidersabdomen.AutoColliderFemaleAutoCollidersabdomen6");
+
+        for (int i = 1; i <= 5; ++i)
+        {
+            Add(
+                $"abdomen.FemaleAutoCollidersabdomen.AutoColliderFemaleAutoCollidersabdomen{6+i}",
+                $"abdomen.FemaleAutoCollidersabdomen.AutoColliderFemaleAutoCollidersabdomen{6+i+5}");
+        }
+
+        Add(
+            "abdomen.FemaleAutoCollidersabdomen.AutoColliderFemaleAutoCollidersabdomen21",
+            "abdomen.FemaleAutoCollidersabdomen.AutoColliderFemaleAutoCollidersabdomen22");
+
+        Add(
+            "abdomen.FemaleAutoCollidersabdomen.AutoColliderFemaleAutoCollidersabdomen23",
+            "abdomen.FemaleAutoCollidersabdomen.AutoColliderFemaleAutoCollidersabdomen24");
+    }
+
+    static private void AddHips()
+    {
+        for (int i = 1; i <= 8; ++i)
+        {
+            Add(
+                $"pelvis.FemaleAutoColliderspelvis.AutoColliderpelvisFL{i}",
+                $"pelvis.FemaleAutoColliderspelvis.AutoColliderpelvisFR{i}");
+        }
+
+        Add(
+            $"pelvis.FemaleAutoColliderspelvis.AutoColliderpelvisFL1b",
+            $"pelvis.FemaleAutoColliderspelvis.AutoColliderpelvisFR1b");
+
+        Add(
+            $"pelvis.FemaleAutoColliderspelvis.AutoColliderpelvisFL1c",
+            $"pelvis.FemaleAutoColliderspelvis.AutoColliderpelvisFR1c");
+
+        for (int i = 1; i <= 6; ++i)
+        {
+            Add(
+                $"pelvis.FemaleAutoColliderspelvis.AutoColliderpelvisL{i}",
+                $"pelvis.FemaleAutoColliderspelvis.AutoColliderpelvisR{i}");
+        }
+
+        Add(
+            "hip.pelvis.HardColliderL",
+            "hip.pelvis.HardColliderR");
+    }
+
+    static private void AddGlutes()
+    {
+        Add(
+            "LGlute.FemaleAutoCollidersLGluteAlt.AutoColliderFemaleAutoCollidersLGlute1",
+            "RGlute.FemaleAutoCollidersRGluteAlt.AutoColliderFemaleAutoCollidersRGlute1");
+
+        for (int i = 1; i <= 7; ++i)
+        {
+            Add(
+                $"LGlute.FemaleAutoCollidersLGluteAlt.AutoColliderFemaleAutoCollidersLGlute1 ({i})",
+                $"RGlute.FemaleAutoCollidersRGluteAlt.AutoColliderFemaleAutoCollidersRGlute1 ({i})");
+        }
+
+        Add(
+            "pelvis.LGlute.HardCollider",
+            "pelvis.RGlute.HardCollider");
+    }
+
+    static private void AddG()
+    {
+        Add(
+            "hip.pelvis._JointAl",
+            "hip.pelvis._JointAr");
+
+        Add(
+            "hip.pelvis._JointGl",
+            "hip.pelvis._JointGr");
+
+        for (int i = 1; i <= 4; ++i)
+        {
+            Add(
+                $"pelvis._JointGl.Collider{i}",
+                $"pelvis._JointGr.Collider{i}");
+        }
+    }
+
+    static private void AddLegs()
+    {
+        for (int i = 1; i <= 16; ++i)
+        {
+            Add(
+                $"lShin.FemaleAutoColliderslShin.AutoColliderFemaleAutoColliderslShin{i}",
+                $"rShin.FemaleAutoCollidersrShin.AutoColliderrShin{i}");
+
+        }
+
+        for (int i = 1; i <= 23; ++i)
+        {
+            Add(
+                $"lThigh.FemaleAutoColliderslThigh.AutoColliderFemaleAutoColliderslThigh{i}",
+                $"rThigh.FemaleAutoCollidersrThigh.AutoColliderFemaleAutoCollidersrThigh{i}");
+        }
+
+        Add(
+            "lThigh.lShin.HardCollider",
+            "rThigh.rShin.HardCollider");
+
+        Add(
+            "pelvis.lThigh.HardCollider",
+            "pelvis.rThigh.HardCollider");
+    }
+
+    static private void AddFeet()
+    {
+        Add(
+            "lToe.lBigToe._Collider",
+            "rToe.rBigToe._Collider");
+
+        for (int i = 1; i <= 9; ++i)
+        {
+            Add(
+                $"lShin.lFoot._Collider{i}",
+                $"rShin.rFoot._Collider{i}");
+        }
+
+        for (int i = 1; i <= 4; ++i)
+        {
+            Add(
+                $"lToe.lSmallToe{i}._Collider",
+                $"rToe.rSmallToe{i}._Collider");
+        }
+
+        Add(
+            "lFoot.lToe._Collider",
+            "rFoot.rToe._Collider");
     }
 }

--- a/src/Links.cs
+++ b/src/Links.cs
@@ -13,20 +13,73 @@ public class Links
         }
     };
 
-    static private List<Link> list = null;
 
-    static public List<Link> GetList()
+    protected List<Link> links_ = new List<Link>();
+    protected Dictionary<string, string> mapA_ = new Dictionary<string, string>();
+    protected Dictionary<string, string> mapB_ = new Dictionary<string, string>();
+
+    protected void Add(string a, string b)
     {
-        if (list == null)
-        {
-            list = new List<Link>();
-            Add();
-        }
-
-        return list;
+        links_.Add(new Link(a, b));
     }
 
-    static private void Add()
+    public string Find(string name)
+    {
+        string s;
+
+        if (mapA_.TryGetValue(name, out s))
+            return s;
+
+        if (mapB_.TryGetValue(name, out s))
+            return s;
+
+        return null;
+    }
+
+    private void CreateDictionaries()
+    {
+        foreach (var link in links_)
+        {
+            mapA_.Add(link.a, link.b);
+            mapA_.Add(link.b, link.a);
+        }
+    }
+
+
+
+    private static Links maleLinks_ = null;
+    private static Links femaleLinks_ = null;
+
+    public static Links Get(Atom atom)
+    {
+        var c = atom?.GetComponentInChildren<DAZCharacter>();
+
+        if (c != null && c.isMale)
+        {
+            if (maleLinks_ == null)
+            {
+                maleLinks_ = new MaleLinks();
+                maleLinks_.CreateDictionaries();
+            }
+
+            return maleLinks_;
+        }
+        else
+        {
+            if (femaleLinks_ == null)
+            {
+                femaleLinks_ = new FemaleLinks();
+                femaleLinks_.CreateDictionaries();
+            }
+
+            return femaleLinks_;
+        }
+    }
+}
+
+public class FemaleLinks : Links
+{
+    public FemaleLinks()
     {
         AddHead();
         AddArms();
@@ -41,12 +94,7 @@ public class Links
         AddFeet();
     }
 
-    static private void Add(string a, string b)
-    {
-        list.Add(new Link(a, b));
-    }
-
-    static private void AddHead()
+    private void AddHead()
     {
         // face hard
         for (int i = 1; i <= 17; ++i)
@@ -86,7 +134,7 @@ public class Links
           "neck.StandardColliders._ColliderBR");
     }
 
-    static private void AddArms()
+    private void AddArms()
     {
         // arms
         Add(
@@ -114,7 +162,7 @@ public class Links
         }
     }
 
-    static private void AddHands()
+    private void AddHands()
     {
         for (int i = 1; i <= 3; ++i)
         {
@@ -200,7 +248,7 @@ public class Links
             "rThumb2.rThumb3._Collider");
     }
 
-    static private void AddChest()
+    private void AddChest()
     {
         Add(
             "chest.FemaleAutoColliderschest.AutoColliderFemaleAutoColliderschest6 (1)",
@@ -222,7 +270,7 @@ public class Links
         }
     }
 
-    static private void AddBreasts()
+    private void AddBreasts()
     {
         Add(
             "lPectoral.FemaleAutoColliderslNipple.AutoColliderFemaleAutoColliderslNipple1",
@@ -244,7 +292,7 @@ public class Links
             "chest.rPectoral._Collider (1)");
     }
 
-    static private void AddAbdomen()
+    private void AddAbdomen()
     {
         Add(
             "abdomen2.FemaleAutoCollidersabdomen2_.AutoColliderFemaleAutoCollidersabdomen2_7",
@@ -270,7 +318,7 @@ public class Links
             "abdomen.FemaleAutoCollidersabdomen.AutoColliderFemaleAutoCollidersabdomen24");
     }
 
-    static private void AddHips()
+    private void AddHips()
     {
         for (int i = 1; i <= 8; ++i)
         {
@@ -299,7 +347,7 @@ public class Links
             "hip.pelvis.HardColliderR");
     }
 
-    static private void AddGlutes()
+    private void AddGlutes()
     {
         Add(
             "LGlute.FemaleAutoCollidersLGluteAlt.AutoColliderFemaleAutoCollidersLGlute1",
@@ -317,7 +365,7 @@ public class Links
             "pelvis.RGlute.HardCollider");
     }
 
-    static private void AddG()
+    private void AddG()
     {
         Add(
             "hip.pelvis._JointAl",
@@ -335,7 +383,7 @@ public class Links
         }
     }
 
-    static private void AddLegs()
+    private void AddLegs()
     {
         for (int i = 1; i <= 16; ++i)
         {
@@ -361,7 +409,7 @@ public class Links
             "pelvis.rThigh.HardCollider");
     }
 
-    static private void AddFeet()
+    private void AddFeet()
     {
         Add(
             "lToe.lBigToe._Collider",
@@ -384,5 +432,14 @@ public class Links
         Add(
             "lFoot.lToe._Collider",
             "rFoot.rToe._Collider");
+    }
+}
+
+
+public class MaleLinks : Links
+{
+    public MaleLinks()
+    {
+        // todo
     }
 }

--- a/src/Links.cs
+++ b/src/Links.cs
@@ -1,0 +1,217 @@
+﻿using System.Collections.Generic;
+
+public class Links
+{
+    public struct Link
+    {
+        public string a, b;
+
+        public Link(string a, string b)
+        {
+            this.a = a;
+            this.b = b;
+        }
+    };
+
+    static private List<Link> list = null;
+
+    static public List<Link> GetList()
+    {
+        if (list == null)
+        {
+            list = new List<Link>();
+            Add();
+        }
+
+        return list;
+    }
+
+    static private void Add()
+    {
+        AddHead();
+        AddArms();
+        AddHands();
+        AddChest();
+    }
+
+    static private void Add(string a, string b)
+    {
+        list.Add(new Link(a, b));
+    }
+
+    static private void AddHead()
+    {
+        // face hard
+        for (int i = 1; i <= 17; ++i)
+        {
+            Add(
+                $"AutoColliders.AutoCollidersFaceHardLeft.AutoColliderAutoCollidersFaceHardLeft{i}",
+                $"AutoColliders.AutoCollidersFaceHardRight.AutoColliderAutoCollidersFaceHardRight{i}");
+        }
+
+        // lower jaw
+        Add(
+            "lowerJaw.lowerJawStandardColliders._ColliderL1bl",
+            "lowerJaw.lowerJawStandardColliders._ColliderL1br");
+
+        for (int i = 1; i <= 4; ++i)
+        {
+            Add(
+               $"lowerJaw.lowerJawStandardColliders._ColliderL{i}l",
+               $"lowerJaw.lowerJawStandardColliders._ColliderL{i}r");
+        }
+
+        // lips
+        Add(
+          "lowerJaw.lowerJawStandardColliders._ColliderLipL",
+          "lowerJaw.lowerJawStandardColliders._ColliderLipR");
+
+        // neck
+        for (int i = 1; i <= 8; ++i)
+        {
+            Add(
+               $"neck.StandardColliders._Collider{i}l",
+               $"neck.StandardColliders._Collider{i}r");
+        }
+
+        Add(
+          "neck.StandardColliders._ColliderBL",
+          "neck.StandardColliders._ColliderBR");
+    }
+
+    static private void AddArms()
+    {
+        // arms
+        Add(
+            "lCollar.lShldr.lForeArm",
+            "rCollar.rShldr.rForeArm");
+
+        for (int i = 1; i <= 3; ++i)
+        {
+            Add(
+                $"lShldr.lForeArm._Collider{i}",
+                $"rShldr.rForeArm._Collider{i}");
+        }
+
+        // shoulders
+        Add(
+            "chest.lCollar.lShldr",
+            "chest.rCollar.rShldr");
+
+
+        for (int i = 1; i <= 2; ++i)
+        {
+            Add(
+                $"lShldr.StandardColliderslShldr._Collider{i}",
+                $"rShldr.StandardCollidersrShldr._Collider{i}");
+        }
+    }
+
+    static private void AddHands()
+    {
+        for (int i = 1; i <= 3; ++i)
+        {
+            Add(
+                $"lHand.lCarpal1._Collider{i}",
+                $"rHand.rCarpal1._Collider{i}");
+        }
+
+        for (int i = 1; i <= 3; ++i)
+        {
+            Add(
+                $"lHand.lCarpal2._Collider{i}",
+                $"rHand.rCarpal2._Collider{i}");
+        }
+
+        Add(
+            "lForeArm.lHand._Collider",
+            "rForeArm.rHand._Collider");
+
+        // index
+        Add(
+            "lCarpal1.lIndex1._Collider",
+            "rCarpal1.rIndex1._Collider");
+
+        Add(
+            "lIndex1.lIndex2._Collider",
+            "rIndex1.rIndex2._Collider");
+
+        Add(
+            "lIndex2.lIndex3._Collider",
+            "rIndex2.rIndex3._Collider");
+
+        // mid
+        Add(
+            "lCarpal1.lMid1._Collider",
+            "rCarpal1.rMid1._Collider");
+
+        Add(
+            "lMid1.lMid2._Collider",
+            "rMid1.rMid2._Collider");
+
+        Add(
+            "lMid2.lMid3._Collider",
+            "rMid2.rMid3._Collider");
+
+        // pinky
+        Add(
+            "lCarpal2.lPinky1._Collider",
+            "rCarpal2.rPinky1._Collider");
+
+        Add(
+            "lPinky1.lPinky2._Collider",
+            "rPinky1.rPinky2._Collider");
+
+        Add(
+            "lPinky2.lPinky3._Collider",
+            "rPinky2.rPinky3._Collider");
+
+        // ring
+        Add(
+            "lCarpal2.lRing1._Collider",
+            "rCarpal2.rRing1._Collider");
+
+        Add(
+            "lRing1.lRing2._Collider",
+            "rRing1.rRing2._Collider");
+
+        Add(
+            "lRing2.lRing3._Collider",
+            "rRing2.rRing3._Collider");
+
+        // thumb
+        Add(
+            "lHand.lThumb1._Collider",
+            "rHand.rThumb1._Collider");
+
+        Add(
+            "lThumb1.lThumb2._Collider",
+            "rThumb1.rThumb2._Collider");
+
+        Add(
+            "lThumb2.lThumb3._Collider",
+            "rThumb2.rThumb3._Collider");
+    }
+
+    static private void AddChest()
+    {
+        Add(
+            "chest.FemaleAutoColliderschest.AutoColliderFemaleAutoColliderschest6 (1)",
+            "chest.FemaleAutoColliderschest.AutoColliderFemaleAutoColliderschest6 (2)");
+
+        Add(
+            "chest.FemaleAutoColliderschest.AutoColliderFemaleAutoColliderschest6 (3)",
+            "chest.FemaleAutoColliderschest.AutoColliderFemaleAutoColliderschest6 (4)");
+
+        Add(
+            "chest.FemaleAutoColliderschest.AutoColliderFemaleAutoColliderschest6 (5)",
+            "chest.FemaleAutoColliderschest.AutoColliderFemaleAutoColliderschest6 (6)");
+
+        for (int i = 1; i <= 3; ++i)
+        {
+            Add(
+                $"chest.FemaleAutoColliderschest.AutoColliderFemaleAutoColliderschestRibL{i}",
+                $"chest.FemaleAutoColliderschest.AutoColliderFemaleAutoColliderschestRibR{i}");
+        }
+    }
+}

--- a/src/Links.cs
+++ b/src/Links.cs
@@ -132,6 +132,34 @@ public class FemaleLinks : Links
         Add(
           "neck.StandardColliders._ColliderBL",
           "neck.StandardColliders._ColliderBR");
+
+        // tongue
+        Add(
+            "tongue03.StandardCollidersTongue03._Collider2",
+            "tongue03.StandardCollidersTongue03._Collider3");
+
+        Add(
+            "tongue04.StandardCollidersTongue04._Collider2",
+            "tongue04.StandardCollidersTongue04._Collider3");
+
+        Add(
+            "tongue04.StandardCollidersTongue04._Collider4",
+            "tongue04.StandardCollidersTongue04._Collider5");
+
+        Add(
+            "tongue05.StandardCollidersTongue05._Collider2",
+            "tongue05.StandardCollidersTongue05._Collider3");
+
+        Add(
+            "tongue05.StandardCollidersTongue05._Collider4",
+            "tongue05.StandardCollidersTongue05._Collider5");
+
+        Add(
+            "tongueTip.StandardCollidersTongueTip._Collider2",
+            "tongueTip.StandardCollidersTongueTip._Collider3");
+        Add(
+            "tongueTip.StandardCollidersTongueTip._Collider4",
+            "tongueTip.StandardCollidersTongueTip._Collider5");
     }
 
     private void AddArms()

--- a/src/Models/AutoColliderModel.cs
+++ b/src/Models/AutoColliderModel.cs
@@ -27,6 +27,17 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
     private float _autoRadiusMultiplier;
     private readonly List<ColliderModel> _ownedColliders = new List<ColliderModel>();
 
+    private JSONStorableBool _collisionEnabledParam = null;
+    private JSONStorableFloat _autoLengthBufferParam = null;
+    private JSONStorableFloat _colliderLengthParam = null;
+    private JSONStorableFloat _autoRadiusBufferParam = null;
+    private JSONStorableFloat _autoRadiusMultiplierParam = null;
+    private JSONStorableFloat _colliderRadiusParam = null;
+    private JSONStorableFloat _hardColliderBufferParam = null;
+    private JSONStorableFloat _colliderLookOffsetParam = null;
+    private JSONStorableFloat _colliderUpOffsetParam = null;
+    private JSONStorableFloat _colliderRightOffsetParam = null;
+
     protected override bool OwnsColliders => true;
 
     public bool collisionEnabled
@@ -137,36 +148,42 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
             RegisterControl(goToAutoColliderGroupButton);
         }
 
+        _collisionEnabledParam = new JSONStorableBool("collisionEnabled", Component.collisionEnabled, value =>
+        {
+            SetCollisionEnabled(value);
+        });
+
         RegisterControl(
-                Script.CreateToggle(RegisterStorable(
-                    new JSONStorableBool("collisionEnabled", Component.collisionEnabled, value =>
-                    {
-                        SetCollisionEnabled(value);
-                    })
+            Script.CreateToggle(
+                RegisterStorable(_collisionEnabledParam
                     .WithDefault(_initialCollisionEnabled)
                 ), "Collision Enabled")
         );
 
         if (Component.useAutoLength)
         {
+            _autoLengthBufferParam = new JSONStorableFloat("autoLengthBuffer", Component.autoLengthBuffer, value =>
+            {
+                SetAutoLengthBuffer(value);
+            }, -0.25f, 0.25f, false);
+
             RegisterControl(
                     Script.CreateFloatSlider(RegisterStorable(
-                        new JSONStorableFloat("autoLengthBuffer", Component.autoLengthBuffer, value =>
-                        {
-                            SetAutoLengthBuffer(value);
-                        }, -0.25f, 0.25f, false)
+                        _autoLengthBufferParam
                         .WithDefault(_initialAutoLengthBuffer)
                     ), "Auto Length Buffer")
             );
         }
         else
         {
+            _colliderLengthParam = new JSONStorableFloat("colliderLength", Component.colliderLength, value =>
+            {
+                SetColliderLength(value);
+            }, 0f, 0.25f, false);
+
             RegisterControl(
                     Script.CreateFloatSlider(RegisterStorable(
-                        new JSONStorableFloat("colliderLength", Component.colliderLength, value =>
-                        {
-                            SetColliderLength(value);
-                        }, 0f, 0.25f, false)
+                        _colliderLengthParam
                         .WithDefault(_initialColliderLength)
                     ), "Length")
             );
@@ -174,75 +191,89 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
 
         if (Component.useAutoRadius)
         {
+            _autoRadiusBufferParam = new JSONStorableFloat("autoRadiusBuffer", Component.autoRadiusBuffer, value =>
+            {
+                SetAutoRadiusBuffer(value);
+            }, -0.025f, 0.025f, false);
+
             RegisterControl(
                     Script.CreateFloatSlider(RegisterStorable(
-                        new JSONStorableFloat("autoRadiusBuffer", Component.autoRadiusBuffer, value =>
-                        {
-                            SetAutoRadiusBuffer(value);
-                        }, -0.025f, 0.025f, false)
+                        _autoRadiusBufferParam
                         .WithDefault(_initialAutoRadiusBuffer)
                     ), "Auto Radius Buffer")
             );
 
+            _autoRadiusMultiplierParam = new JSONStorableFloat("autoRadiusMultiplier", Component.autoRadiusMultiplier, value =>
+            {
+                SetAutoRadiusMultiplier(value);
+            }, 0.001f, 2f, false);
+
             RegisterControl(
                     Script.CreateFloatSlider(RegisterStorable(
-                        new JSONStorableFloat("autoRadiusMultiplier", Component.autoRadiusMultiplier, value =>
-                        {
-                            SetAutoRadiusMultiplier(value);
-                        }, 0.001f, 2f, false)
+                        _autoRadiusMultiplierParam
                         .WithDefault(_initialAutoRadiusMultiplier)
                     ), "Auto Radius Multiplier")
             );
         }
         else
         {
+            _colliderRadiusParam = new JSONStorableFloat("colliderRadius", Component.colliderRadius, value =>
+            {
+                SetColliderRadius(value);
+            }, 0f, 0.25f, false);
+
             RegisterControl(
                     Script.CreateFloatSlider(RegisterStorable(
-                        new JSONStorableFloat("colliderRadius", Component.colliderRadius, value =>
-                        {
-                            SetColliderRadius(value);
-                        }, 0f, 0.25f, false)
+                        _colliderRadiusParam
                         .WithDefault(_initialColliderRadius)
                     ), "Radius")
             );
 
+            _hardColliderBufferParam = new JSONStorableFloat("hardColliderBuffer", Component.hardColliderBuffer, value =>
+            {
+                SetHardColliderBuffer(value);
+            }, 0f, 0.25f, false);
+
             RegisterControl(
                     Script.CreateFloatSlider(RegisterStorable(
-                        new JSONStorableFloat("hardColliderBuffer", Component.hardColliderBuffer, value =>
-                        {
-                            SetHardColliderBuffer(value);
-                        }, 0f, 0.25f, false)
+                        _hardColliderBufferParam
                         .WithDefault(_initialHardColliderBuffer)
                     ), "Hard Collider Buffer")
             );
         }
 
+        _colliderLookOffsetParam = new JSONStorableFloat("colliderLookOffset", Component.colliderLookOffset, value =>
+        {
+            SetColliderLookOffset(value);
+        }, MakeMinOffset(Component.colliderLookOffset), MakeMaxOffset(Component.colliderLookOffset), false);
+
         RegisterControl(
                 Script.CreateFloatSlider(RegisterStorable(
-                    new JSONStorableFloat("colliderLookOffset", Component.colliderLookOffset, value =>
-                    {
-                        SetColliderLookOffset(value);
-                    }, MakeMinOffset(Component.colliderLookOffset), MakeMaxOffset(Component.colliderLookOffset), false)
+                    _colliderLookOffsetParam
                     .WithDefault(_initialColliderLookOffset)
                 ), "Look Offset")
         );
 
+        _colliderUpOffsetParam = new JSONStorableFloat("colliderUpOffset", Component.colliderUpOffset, value =>
+        {
+            SetColliderUpOffset(value);
+        }, MakeMinOffset(Component.colliderUpOffset), MakeMaxOffset(Component.colliderUpOffset), false);
+
         RegisterControl(
                 Script.CreateFloatSlider(RegisterStorable(
-                    new JSONStorableFloat("colliderUpOffset", Component.colliderUpOffset, value =>
-                    {
-                        SetColliderUpOffset(value);
-                    }, MakeMinOffset(Component.colliderUpOffset), MakeMaxOffset(Component.colliderUpOffset), false)
+                    _colliderUpOffsetParam
                     .WithDefault(_initialColliderUpOffset)
                 ), "Up Offset")
         );
 
+        _colliderRightOffsetParam = new JSONStorableFloat("colliderRightOffset", Component.colliderRightOffset, value =>
+        {
+            SetColliderRightOffset(value);
+        }, MakeMinOffset(Component.colliderRightOffset), MakeMaxOffset(Component.colliderRightOffset), false);
+
         RegisterControl(
                 Script.CreateFloatSlider(RegisterStorable(
-                    new JSONStorableFloat("colliderRightOffset", Component.colliderRightOffset, value =>
-                    {
-                        SetColliderRightOffset(value);
-                    }, MakeMinOffset(Component.colliderRightOffset), MakeMaxOffset(Component.colliderRightOffset), false)
+                    _colliderRightOffsetParam
                     .WithDefault(_initialColliderRightOffset)
                 ), "Right Offset")
         );
@@ -250,6 +281,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
 
     private void SetCollisionEnabled(bool value)
     {
+        if (_collisionEnabledParam != null) _collisionEnabledParam.val = value;
         Component.collisionEnabled = _collisionEnabled = value;
         RefreshAutoCollider();
         SetModified();
@@ -258,6 +290,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
 
     private void SetAutoLengthBuffer(float value)
     {
+        if (_autoLengthBufferParam != null) _autoLengthBufferParam.val = value;
         Component.autoLengthBuffer = _autoLengthBuffer = value;
         RefreshAutoCollider();
         SetModified();
@@ -266,6 +299,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
 
     private void SetColliderLength(float value)
     {
+        if (_colliderLengthParam != null) _colliderLengthParam.val = value;
         Component.colliderLength = _colliderLength = value;
         RefreshAutoCollider();
         SetModified();
@@ -274,6 +308,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
 
     private void SetAutoRadiusBuffer(float value)
     {
+        if (_autoRadiusBufferParam != null) _autoRadiusBufferParam.val = value;
         Component.autoRadiusBuffer = _autoRadiusBuffer = value;
         RefreshAutoCollider();
         SetModified();
@@ -282,6 +317,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
 
     private void SetAutoRadiusMultiplier(float value)
     {
+        if (_autoRadiusMultiplierParam != null) _autoRadiusMultiplierParam.val = value;
         Component.autoRadiusMultiplier = _autoRadiusMultiplier = value;
         RefreshAutoCollider();
         SetModified();
@@ -290,6 +326,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
 
     private void SetColliderRadius(float value)
     {
+        if (_colliderRadiusParam != null) _colliderRadiusParam.val = value;
         Component.colliderRadius = _colliderRadius = value;
         RefreshAutoCollider();
         SetModified();
@@ -298,6 +335,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
 
     private void SetHardColliderBuffer(float value)
     {
+        if (_hardColliderBufferParam != null) _hardColliderBufferParam.val = value;
         Component.hardColliderBuffer = _hardColliderBuffer = value;
         RefreshAutoCollider();
         SetModified();
@@ -306,6 +344,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
 
     private void SetColliderLookOffset(float value)
     {
+        if (_colliderLookOffsetParam != null) _colliderLookOffsetParam.val = value;
         Component.colliderLookOffset = _colliderLookOffset = value;
         RefreshAutoCollider();
         SetModified();
@@ -314,6 +353,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
 
     private void SetColliderUpOffset(float value)
     {
+        if (_colliderUpOffsetParam != null) _colliderUpOffsetParam.val = value;
         Component.colliderUpOffset = _colliderUpOffset = value;
         RefreshAutoCollider();
         SetModified();
@@ -322,6 +362,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
 
     private void SetColliderRightOffset(float value)
     {
+        if (_colliderRightOffsetParam != null) _colliderRightOffsetParam.val = value;
         Component.colliderRightOffset = _colliderRightOffset = value;
         RefreshAutoCollider();
         SetModified();

--- a/src/Models/AutoColliderModel.cs
+++ b/src/Models/AutoColliderModel.cs
@@ -141,10 +141,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
                 Script.CreateToggle(RegisterStorable(
                     new JSONStorableBool("collisionEnabled", Component.collisionEnabled, value =>
                     {
-                        Component.collisionEnabled = _collisionEnabled = value;
-                        RefreshAutoCollider();
-                        SetModified();
-                        SetLinked("collisionEnabled", (v) => Component.collisionEnabled = v, value);
+                        SetCollisionEnabled(value);
                     })
                     .WithDefault(_initialCollisionEnabled)
                 ), "Collision Enabled")
@@ -156,10 +153,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
                     Script.CreateFloatSlider(RegisterStorable(
                         new JSONStorableFloat("autoLengthBuffer", Component.autoLengthBuffer, value =>
                         {
-                            Component.autoLengthBuffer = _autoLengthBuffer = value;
-                            RefreshAutoCollider();
-                            SetModified();
-                            SetLinked("autoLengthBuffer", (v) => Component.autoLengthBuffer = v, value);
+                            SetAutoLengthBuffer(value);
                         }, -0.25f, 0.25f, false)
                         .WithDefault(_initialAutoLengthBuffer)
                     ), "Auto Length Buffer")
@@ -171,10 +165,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
                     Script.CreateFloatSlider(RegisterStorable(
                         new JSONStorableFloat("colliderLength", Component.colliderLength, value =>
                         {
-                            Component.colliderLength = _colliderLength = value;
-                            RefreshAutoCollider();
-                            SetModified();
-                            SetLinked("colliderLength", (v) => Component.colliderLength = v, value);
+                            SetColliderLength(value);
                         }, 0f, 0.25f, false)
                         .WithDefault(_initialColliderLength)
                     ), "Length")
@@ -187,10 +178,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
                     Script.CreateFloatSlider(RegisterStorable(
                         new JSONStorableFloat("autoRadiusBuffer", Component.autoRadiusBuffer, value =>
                         {
-                            Component.autoRadiusBuffer = _autoRadiusBuffer = value;
-                            RefreshAutoCollider();
-                            SetModified();
-                            SetLinked("autoRadiusBuffer", (v) => Component.autoRadiusBuffer = v, value);
+                            SetAutoRadiusBuffer(value);
                         }, -0.025f, 0.025f, false)
                         .WithDefault(_initialAutoRadiusBuffer)
                     ), "Auto Radius Buffer")
@@ -200,10 +188,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
                     Script.CreateFloatSlider(RegisterStorable(
                         new JSONStorableFloat("autoRadiusMultiplier", Component.autoRadiusMultiplier, value =>
                         {
-                            Component.autoRadiusMultiplier = _autoRadiusMultiplier = value;
-                            RefreshAutoCollider();
-                            SetModified();
-                            SetLinked("autoRadiusMultiplier", (v) => Component.autoRadiusMultiplier = v, value);
+                            SetAutoRadiusMultiplier(value);
                         }, 0.001f, 2f, false)
                         .WithDefault(_initialAutoRadiusMultiplier)
                     ), "Auto Radius Multiplier")
@@ -215,10 +200,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
                     Script.CreateFloatSlider(RegisterStorable(
                         new JSONStorableFloat("colliderRadius", Component.colliderRadius, value =>
                         {
-                            Component.colliderRadius = _colliderRadius = value;
-                            RefreshAutoCollider();
-                            SetModified();
-                            SetLinked("colliderRadius", (v) => Component.colliderRadius = v, value);
+                            SetColliderRadius(value);
                         }, 0f, 0.25f, false)
                         .WithDefault(_initialColliderRadius)
                     ), "Radius")
@@ -228,10 +210,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
                     Script.CreateFloatSlider(RegisterStorable(
                         new JSONStorableFloat("hardColliderBuffer", Component.hardColliderBuffer, value =>
                         {
-                            Component.hardColliderBuffer = _hardColliderBuffer = value;
-                            RefreshAutoCollider();
-                            SetModified();
-                            SetLinked("hardColliderBuffer", (v) => Component.hardColliderBuffer = v, value);
+                            SetHardColliderBuffer(value);
                         }, 0f, 0.25f, false)
                         .WithDefault(_initialHardColliderBuffer)
                     ), "Hard Collider Buffer")
@@ -242,10 +221,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
                 Script.CreateFloatSlider(RegisterStorable(
                     new JSONStorableFloat("colliderLookOffset", Component.colliderLookOffset, value =>
                     {
-                        Component.colliderLookOffset = _colliderLookOffset = value;
-                        RefreshAutoCollider();
-                        SetModified();
-                        SetLinked("colliderLookOffset", (v) => Component.colliderLookOffset = v, value);
+                        SetColliderLookOffset(value);
                     }, MakeMinOffset(Component.colliderLookOffset), MakeMaxOffset(Component.colliderLookOffset), false)
                     .WithDefault(_initialColliderLookOffset)
                 ), "Look Offset")
@@ -255,10 +231,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
                 Script.CreateFloatSlider(RegisterStorable(
                     new JSONStorableFloat("colliderUpOffset", Component.colliderUpOffset, value =>
                     {
-                        Component.colliderUpOffset = _colliderUpOffset = value;
-                        RefreshAutoCollider();
-                        SetModified();
-                        SetLinked("colliderUpOffset", (v) => Component.colliderUpOffset = v, value);
+                        SetColliderUpOffset(value);
                     }, MakeMinOffset(Component.colliderUpOffset), MakeMaxOffset(Component.colliderUpOffset), false)
                     .WithDefault(_initialColliderUpOffset)
                 ), "Up Offset")
@@ -268,151 +241,91 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
                 Script.CreateFloatSlider(RegisterStorable(
                     new JSONStorableFloat("colliderRightOffset", Component.colliderRightOffset, value =>
                     {
-                        Component.colliderRightOffset = _colliderRightOffset = value;
-                        RefreshAutoCollider();
-                        SetModified();
-                        SetLinked("colliderRightOffset", (v) => Component.colliderRightOffset = v, -value);
+                        SetColliderRightOffset(value);
                     }, MakeMinOffset(Component.colliderRightOffset), MakeMaxOffset(Component.colliderRightOffset), false)
                     .WithDefault(_initialColliderRightOffset)
                 ), "Right Offset")
         );
     }
 
-    struct Link
+    private void SetCollisionEnabled(bool value)
     {
-        public string a, b;
-
-        public Link(string a, string b)
-        {
-            this.a = a;
-            this.b = b;
-        }
-    };
-
-    private static bool ChangingLink = false;
-
-    public override IModel Linked
-    {
-        get
-        {
-            return FindLinked(AutoCollider.name);
-        }
+        Component.collisionEnabled = _collisionEnabled = value;
+        RefreshAutoCollider();
+        SetModified();
+        SetLinked((m, v) => (m as AutoColliderModel)?.SetCollisionEnabled(value), value);
     }
 
-    public void SetLinked(string storable, Action<float> set, float value)
+    private void SetAutoLengthBuffer(float value)
     {
-        if (ChangingLink)
-            return;
-
-        try
-        {
-            ChangingLink = true;
-            SetLinkedImpl(storable, set, value);
-        }
-        finally
-        {
-            ChangingLink = false;
-        }
+        Component.autoLengthBuffer = _autoLengthBuffer = value;
+        RefreshAutoCollider();
+        SetModified();
+        SetLinked((m, v) => (m as AutoColliderModel)?.SetAutoLengthBuffer(v), value);
     }
 
-    public void SetLinked(string storable, Action<bool> set, bool value)
+    private void SetColliderLength(float value)
     {
-        if (ChangingLink)
-            return;
-
-        try
-        {
-            ChangingLink = true;
-            SetLinkedImpl(storable, set, value);
-        }
-        finally
-        {
-            ChangingLink = false;
-        }
+        Component.colliderLength = _colliderLength = value;
+        RefreshAutoCollider();
+        SetModified();
+        SetLinked((m, v) => (m as AutoColliderModel)?.SetColliderLength(v), value);
     }
 
-    private void SetLinkedImpl(string storable, Action<float> set, float value)
+    private void SetAutoRadiusBuffer(float value)
     {
-        var linked = Linked as AutoColliderModel;
-        if (linked == null)
-        {
-            SuperController.LogError($"no link for {Component.name}");
-            return;
-        }
-
-        var param = linked.FindStorable(storable);
-        if (param == null)
-        {
-            set(value);
-            linked.RefreshAutoCollider();
-            linked.SetModified();
-        }
-        else
-        {
-            var fparam = param as JSONStorableFloat;
-            if (fparam != null)
-                fparam.val = value;
-        }
+        Component.autoRadiusBuffer = _autoRadiusBuffer = value;
+        RefreshAutoCollider();
+        SetModified();
+        SetLinked((m, v) => (m as AutoColliderModel)?.SetAutoRadiusBuffer(v), value);
     }
 
-    private void SetLinkedImpl(string storable, Action<bool> set, bool value)
+    private void SetAutoRadiusMultiplier(float value)
     {
-        var linked = Linked as AutoColliderModel;
-        if (linked == null)
-        {
-            SuperController.LogError($"no link for {Component.name}");
-            return;
-        }
-
-        var param = linked.FindStorable(storable);
-        if (param == null)
-        {
-            set(value);
-            linked.RefreshAutoCollider();
-            linked.SetModified();
-        }
-        else
-        {
-            var bparam = param as JSONStorableBool;
-            if (bparam != null)
-                bparam.val = value;
-        }
+        Component.autoRadiusMultiplier = _autoRadiusMultiplier = value;
+        RefreshAutoCollider();
+        SetModified();
+        SetLinked((m, v) => (m as AutoColliderModel)?.SetAutoRadiusMultiplier(v), value);
     }
 
-    private AutoColliderModel FindLinked(string name)
+    private void SetColliderRadius(float value)
     {
-        var map = new List<Link>();
+        Component.colliderRadius = _colliderRadius = value;
+        RefreshAutoCollider();
+        SetModified();
+        SetLinked((m, v) => (m as AutoColliderModel)?.SetColliderRadius(v), value);
+    }
 
-        for (int i = 0; i <= 17; ++i)
-        {
-            map.Add(new Link(
-                $"AutoColliderAutoCollidersFaceHardLeft{i}",
-                $"AutoColliderAutoCollidersFaceHardRight{i}"));
-        }
+    private void SetHardColliderBuffer(float value)
+    {
+        Component.hardColliderBuffer = _hardColliderBuffer = value;
+        RefreshAutoCollider();
+        SetModified();
+        SetLinked((m, v) => (m as AutoColliderModel)?.SetHardColliderBuffer(v), value);
+    }
 
-        var ce = (ColliderEditor)Script;
+    private void SetColliderLookOffset(float value)
+    {
+        Component.colliderLookOffset = _colliderLookOffset = value;
+        RefreshAutoCollider();
+        SetModified();
+        SetLinked((m, v) => (m as AutoColliderModel)?.SetColliderLookOffset(v), value);
+    }
 
-        foreach (Link ln in map)
-        {
-            if (ln.a == name)
-            {
-                foreach (var ac in ce.EditablesList.AutoColliders)
-                {
-                    if (ac.Component.name == ln.b)
-                        return ac;
-                }
-            }
-            else if (ln.b == name)
-            {
-                foreach (var ac in ce.EditablesList.AutoColliders)
-                {
-                    if (ac.Component.name == ln.a)
-                        return ac;
-                }
-            }
-        }
+    private void SetColliderUpOffset(float value)
+    {
+        Component.colliderUpOffset = _colliderUpOffset = value;
+        RefreshAutoCollider();
+        SetModified();
+        SetLinked((m, v) => (m as AutoColliderModel)?.SetColliderUpOffset(v), value);
+    }
 
-        return null;
+    private void SetColliderRightOffset(float value)
+    {
+        Component.colliderRightOffset = _colliderRightOffset = value;
+        RefreshAutoCollider();
+        SetModified();
+        SetLinked((m, v) => (m as AutoColliderModel)?.SetColliderRightOffset(v), -value);
     }
 
     public void RefreshAutoCollider()

--- a/src/Models/CapsuleColliderModel.cs
+++ b/src/Models/CapsuleColliderModel.cs
@@ -70,64 +70,106 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
     {
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("radius", Collider.radius, value =>
         {
-            Collider.radius = _radius = value;
-            _gpu?.UpdateData();
-            SetModified();
-            SyncPreview();
+            SetRadius(value);
         }, 0f, _initialRadius * 4f, false)).WithDefault(_initialRadius), "Radius"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("height", Collider.height, value =>
         {
-            Collider.height = _height = value;
-            _gpu?.UpdateData();
-            SetModified();
-            SyncPreview();
+            SetHeight(value);
         }, 0f, _initialHeight * 4f, false)).WithDefault(_initialHeight), "Height"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerX", Collider.center.x, value =>
         {
-            var center = _center;
-            center.x = value;
-            Collider.center = _center = center;
-            _gpu?.UpdateData();
-            SetModified();
-            SyncPreview();
+            SetCenterX(value);
         }, MakeMinPosition(Collider.center.x), MakeMaxPosition(Collider.center.x), false)).WithDefault(_initialCenter.x), "Center.X"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerY", Collider.center.y, value =>
         {
-            var center = _center;
-            center.y = value;
-            Collider.center = _center = center;
-            _gpu?.UpdateData();
-            SetModified();
-            SyncPreview();
+            SetCenterY(value);
         }, MakeMinPosition(Collider.center.y), MakeMaxPosition(Collider.center.y), false)).WithDefault(_initialCenter.y), "Center.Y"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerZ", Collider.center.z, value =>
         {
-            var center = _center;
-            center.z = value;
-            Collider.center = _center = center;
-            _gpu?.UpdateData();
-            SetModified();
-            SyncPreview();
+            SetCenterZ(value);
         }, MakeMinPosition(Collider.center.z), MakeMaxPosition(Collider.center.z), false)).WithDefault(_initialCenter.z), "Center.Z"));
 
         if (_gpu != null)
         {
             RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("gpu.friction", _gpu.friction, value =>
             {
-                _gpu.friction = _gpuFriction = value;
-                SetModified();
+                SetGpuFriction(value);
             }, 0f, Mathf.Ceil(_initialGpuFriction) * 2f, false)).WithDefault(_gpu.friction), "GPU Friction"));
 
             RegisterControl(Script.CreateToggle(RegisterStorable(new JSONStorableBool("gpu.enabled", _gpu.enabled, (bool value) =>
             {
-                _gpu.enabled = _gpuEnabled = value;
-                SetModified();
+                SetGpuEnabled(value);
             }).WithDefault(_initialGpuEnabled)), "GPU Collider Enabled"));
         }
+    }
+
+    private void SetRadius(float value)
+    {
+        Collider.radius = _radius = value;
+        _gpu?.UpdateData();
+        SetModified();
+        SyncPreview();
+        SetLinked((m, v) => (m as CapsuleColliderModel)?.SetRadius(v), value);
+    }
+
+    private void SetHeight(float value)
+    {
+        Collider.height = _height = value;
+        _gpu?.UpdateData();
+        SetModified();
+        SyncPreview();
+        SetLinked((m, v) => (m as CapsuleColliderModel)?.SetHeight(v), value);
+    }
+
+    private void SetCenterX(float value)
+    {
+        var center = _center;
+        center.x = value;
+        Collider.center = _center = center;
+        _gpu?.UpdateData();
+        SetModified();
+        SyncPreview();
+        SetLinked((m, v) => (m as CapsuleColliderModel)?.SetCenterX(v), -value);
+    }
+
+    private void SetCenterY(float value)
+    {
+        var center = _center;
+        center.y = value;
+        Collider.center = _center = center;
+        _gpu?.UpdateData();
+        SetModified();
+        SyncPreview();
+        SetLinked((m, v) => (m as CapsuleColliderModel)?.SetCenterY(v), value);
+    }
+
+    private void SetCenterZ(float value)
+    {
+        var center = _center;
+        center.z = value;
+        Collider.center = _center = center;
+        _gpu?.UpdateData();
+        SetModified();
+        SyncPreview();
+        SetLinked((m, v) => (m as CapsuleColliderModel)?.SetCenterZ(v), value);
+    }
+
+    private void SetGpuFriction(float value)
+    {
+        _gpu.friction = _gpuFriction = value;
+        SetModified();
+        SetLinked((m, v) => (m as CapsuleColliderModel)?.SetGpuFriction(v), value);
+    }
+
+    private void SetGpuEnabled(bool value)
+    {
+        _gpu.enabled = _gpuEnabled = value;
+        SetModified();
+        SetLinked((m, v) => (m as CapsuleColliderModel)?.SetGpuEnabled(v), value);
     }
 
     protected override void DoLoadJson(JSONClass jsonClass)

--- a/src/Models/CapsuleColliderModel.cs
+++ b/src/Models/CapsuleColliderModel.cs
@@ -16,6 +16,14 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
     private float _gpuFriction;
     private bool _gpuEnabled;
 
+    private JSONStorableFloat _radiusParam = null;
+    private JSONStorableFloat _heightParam = null;
+    private JSONStorableFloat _centerXParam = null;
+    private JSONStorableFloat _centerYParam = null;
+    private JSONStorableFloat _centerZParam = null;
+    private JSONStorableFloat _gpuFrictionParam = null;
+    private JSONStorableBool _gpuEnabledParam = null;
+
     public CapsuleColliderModel(MVRScript parent, CapsuleCollider collider, ColliderPreviewConfig config)
         : base(parent, collider, config)
     {
@@ -68,47 +76,67 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
 
     public override void DoCreateControls()
     {
-        RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("radius", Collider.radius, value =>
+        _radiusParam = new JSONStorableFloat("radius", Collider.radius, value =>
         {
             SetRadius(value);
-        }, 0f, _initialRadius * 4f, false)).WithDefault(_initialRadius), "Radius"));
+        }, 0f, _initialRadius * 4f, false);
 
-        RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("height", Collider.height, value =>
+        RegisterControl(Script.CreateFloatSlider(RegisterStorable(_radiusParam).WithDefault(_initialRadius), "Radius"));
+
+
+        _heightParam = new JSONStorableFloat("height", Collider.height, value =>
         {
             SetHeight(value);
-        }, 0f, _initialHeight * 4f, false)).WithDefault(_initialHeight), "Height"));
+        }, 0f, _initialHeight * 4f, false);
 
-        RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerX", Collider.center.x, value =>
+        RegisterControl(Script.CreateFloatSlider(RegisterStorable(_heightParam).WithDefault(_initialHeight), "Height"));
+
+
+        _centerXParam = new JSONStorableFloat("centerX", Collider.center.x, value =>
         {
             SetCenterX(value);
-        }, MakeMinPosition(Collider.center.x), MakeMaxPosition(Collider.center.x), false)).WithDefault(_initialCenter.x), "Center.X"));
+        }, MakeMinPosition(Collider.center.x), MakeMaxPosition(Collider.center.x), false);
 
-        RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerY", Collider.center.y, value =>
+        RegisterControl(Script.CreateFloatSlider(RegisterStorable(_centerXParam).WithDefault(_initialCenter.x), "Center.X"));
+
+
+        _centerYParam = new JSONStorableFloat("centerY", Collider.center.y, value =>
         {
             SetCenterY(value);
-        }, MakeMinPosition(Collider.center.y), MakeMaxPosition(Collider.center.y), false)).WithDefault(_initialCenter.y), "Center.Y"));
+        }, MakeMinPosition(Collider.center.y), MakeMaxPosition(Collider.center.y), false);
 
-        RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerZ", Collider.center.z, value =>
+        RegisterControl(Script.CreateFloatSlider(RegisterStorable(_centerYParam).WithDefault(_initialCenter.y), "Center.Y"));
+
+
+        _centerZParam = new JSONStorableFloat("centerZ", Collider.center.z, value =>
         {
             SetCenterZ(value);
-        }, MakeMinPosition(Collider.center.z), MakeMaxPosition(Collider.center.z), false)).WithDefault(_initialCenter.z), "Center.Z"));
+        }, MakeMinPosition(Collider.center.z), MakeMaxPosition(Collider.center.z), false);
+
+        RegisterControl(Script.CreateFloatSlider(RegisterStorable(_centerZParam).WithDefault(_initialCenter.z), "Center.Z"));
+
 
         if (_gpu != null)
         {
-            RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("gpu.friction", _gpu.friction, value =>
+            _gpuFrictionParam = new JSONStorableFloat("gpu.friction", _gpu.friction, value =>
             {
                 SetGpuFriction(value);
-            }, 0f, Mathf.Ceil(_initialGpuFriction) * 2f, false)).WithDefault(_gpu.friction), "GPU Friction"));
+            }, 0f, Mathf.Ceil(_initialGpuFriction) * 2f, false);
 
-            RegisterControl(Script.CreateToggle(RegisterStorable(new JSONStorableBool("gpu.enabled", _gpu.enabled, (bool value) =>
+            RegisterControl(Script.CreateFloatSlider(RegisterStorable(_gpuFrictionParam).WithDefault(_gpu.friction), "GPU Friction"));
+
+            _gpuEnabledParam = new JSONStorableBool("gpu.enabled", _gpu.enabled, (bool value) =>
             {
                 SetGpuEnabled(value);
-            }).WithDefault(_initialGpuEnabled)), "GPU Collider Enabled"));
+            });
+
+            RegisterControl(Script.CreateToggle(RegisterStorable(_gpuEnabledParam.WithDefault(_initialGpuEnabled)), "GPU Collider Enabled"));
         }
     }
 
     private void SetRadius(float value)
     {
+        if (_radiusParam != null) _radiusParam.val = value;
         Collider.radius = _radius = value;
         _gpu?.UpdateData();
         SetModified();
@@ -118,6 +146,7 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
 
     private void SetHeight(float value)
     {
+        if (_heightParam != null) _heightParam.val = value;
         Collider.height = _height = value;
         _gpu?.UpdateData();
         SetModified();
@@ -127,6 +156,7 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
 
     private void SetCenterX(float value)
     {
+        if (_centerXParam != null) _centerXParam.val = value;
         var center = _center;
         center.x = value;
         Collider.center = _center = center;
@@ -138,6 +168,7 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
 
     private void SetCenterY(float value)
     {
+        if (_centerYParam != null) _centerYParam.val = value;
         var center = _center;
         center.y = value;
         Collider.center = _center = center;
@@ -149,6 +180,7 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
 
     private void SetCenterZ(float value)
     {
+        if (_centerZParam != null) _centerZParam.val = value;
         var center = _center;
         center.z = value;
         Collider.center = _center = center;
@@ -160,6 +192,7 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
 
     private void SetGpuFriction(float value)
     {
+        if (_gpuFrictionParam != null) _gpuFrictionParam.val = value;
         _gpu.friction = _gpuFriction = value;
         SetModified();
         SetLinked((m, v) => (m as CapsuleColliderModel)?.SetGpuFriction(v), value);
@@ -167,6 +200,7 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
 
     private void SetGpuEnabled(bool value)
     {
+        if (_gpuEnabledParam != null) _gpuEnabledParam.val = value;
         _gpu.enabled = _gpuEnabled = value;
         SetModified();
         SetLinked((m, v) => (m as CapsuleColliderModel)?.SetGpuEnabled(v), value);

--- a/src/Models/IModel.cs
+++ b/src/Models/IModel.cs
@@ -10,6 +10,7 @@ public interface IModel
     bool Shown { get; set; }
     bool Selected { get; set; }
     bool Modified { get; }
+    IModel Linked { get; }
 
     void UpdatePreviewFromConfig();
     void SyncPreview();

--- a/src/Models/IModel.cs
+++ b/src/Models/IModel.cs
@@ -6,6 +6,7 @@ public interface IModel
     Group Group { get; }
     string Id { get; }
     string Label { get; }
+    string QualifiedName { get; }
     bool IsDuplicate { get; }
     bool Shown { get; set; }
     bool Selected { get; set; }

--- a/src/Models/ModelBase.cs
+++ b/src/Models/ModelBase.cs
@@ -260,17 +260,6 @@ public abstract class ModelBase<T> where T : Component
     }
 
 
-    struct Link
-    {
-        public string a, b;
-
-        public Link(string a, string b)
-        {
-            this.a = a;
-            this.b = b;
-        }
-    };
-
     private static bool ChangingLink = false;
 
     public virtual IModel Linked
@@ -350,59 +339,23 @@ public abstract class ModelBase<T> where T : Component
 
     private ModelBase<T> FindLinked()
     {
-        var map = new List<Link>();
-
-        for (int i = 0; i <= 17; ++i)
-        {
-            map.Add(new Link(
-                $"AutoColliders.AutoCollidersFaceHardLeft.AutoColliderAutoCollidersFaceHardLeft{i}",
-                $"AutoColliders.AutoCollidersFaceHardRight.AutoColliderAutoCollidersFaceHardRight{i}"));
-        }
-
-        map.Add(new Link(
-            "lowerJaw.lowerJawStandardColliders._ColliderL1bl",
-            "lowerJaw.lowerJawStandardColliders._ColliderL1br"));
-
-        for (int i = 0; i <= 4; ++i)
-        {
-            map.Add(new Link(
-               $"lowerJaw.lowerJawStandardColliders._ColliderL{i}l",
-               $"lowerJaw.lowerJawStandardColliders._ColliderL{i}r"));
-        }
-
-        map.Add(new Link(
-          "lowerJaw.lowerJawStandardColliders._ColliderLipL",
-          "lowerJaw.lowerJawStandardColliders._ColliderLipR"));
-
-        for (int i = 0; i <= 8; ++i)
-        {
-            map.Add(new Link(
-               $"neck.StandardColliders._Collider{i}l",
-               $"neck.StandardColliders._Collider{i}r"));
-        }
-
-        map.Add(new Link(
-          "neck.StandardColliders._ColliderBL",
-          "neck.StandardColliders._ColliderBR"));
-
-
-
         var name = QualifiedName;
+
         SuperController.LogError("FindLinked: " + name);
 
         var ce = (ColliderEditor)Script;
 
         ModelBase<T> linked = null;
 
-        linked = FindLinkedIn(name, map, ce.EditablesList.Colliders);
+        linked = FindLinkedIn(name, ce.EditablesList.Colliders);
         if (linked != null)
             return linked;
 
-        linked = FindLinkedIn(name, map, ce.EditablesList.AutoColliders);
+        linked = FindLinkedIn(name, ce.EditablesList.AutoColliders);
         if (linked != null)
             return linked;
 
-        linked = FindLinkedIn(name, map, ce.EditablesList.Rigidbodies);
+        linked = FindLinkedIn(name, ce.EditablesList.Rigidbodies);
         if (linked != null)
             return linked;
 
@@ -410,9 +363,11 @@ public abstract class ModelBase<T> where T : Component
     }
 
     private ModelBase<T> FindLinkedIn<U>(
-        string name, List<Link> links, List<U> list) where U : IModel
+        string name, List<U> list) where U : IModel
     {
-        foreach (Link ln in links)
+        var links = Links.GetList();
+
+        foreach (Links.Link ln in links)
         {
             if (ln.a == name)
             {

--- a/src/Models/ModelBase.cs
+++ b/src/Models/ModelBase.cs
@@ -43,18 +43,6 @@ public abstract class ModelBase<T> where T : Component
 		return val + 0.025f;
 	}
 
-    public JSONStorableParam FindStorable(string name)
-    {
-        foreach (var p in _controlsStorables)
-        {
-            SuperController.LogError(p.name);
-            if (p.name == name)
-                return p;
-        }
-
-        return null;
-    }
-
     public bool Selected
     {
         get { return _selected; }

--- a/src/Models/ModelBase.cs
+++ b/src/Models/ModelBase.cs
@@ -335,21 +335,25 @@ public abstract class ModelBase<T> where T : Component
 
     private ModelBase<T> DoFindLinked()
     {
-        var name = QualifiedName;
+        var links = Links.Get(Script.containingAtom);
+
+        var linkedName = links.Find(QualifiedName);
+        if (linkedName == null)
+            return null;
 
         var ce = (ColliderEditor)Script;
 
-        ModelBase<T> linked = null;
+        ModelBase<T> linked;
 
-        linked = FindLinkedIn(name, ce.EditablesList.Colliders);
+        linked = FindLinkedIn(linkedName, ce.EditablesList.Colliders);
         if (linked != null)
             return linked;
 
-        linked = FindLinkedIn(name, ce.EditablesList.AutoColliders);
+        linked = FindLinkedIn(linkedName, ce.EditablesList.AutoColliders);
         if (linked != null)
             return linked;
 
-        linked = FindLinkedIn(name, ce.EditablesList.Rigidbodies);
+        linked = FindLinkedIn(linkedName, ce.EditablesList.Rigidbodies);
         if (linked != null)
             return linked;
 
@@ -357,14 +361,8 @@ public abstract class ModelBase<T> where T : Component
     }
 
     private ModelBase<T> FindLinkedIn<U>(
-        string name, List<U> list) where U : IModel
+        string linkedName, List<U> list) where U : IModel
     {
-        var links = Links.Get(Script.containingAtom);
-
-        var linkedName = links.Find(name);
-        if (linkedName == null)
-            return null;
-
         foreach (var m in list)
         {
             if (m.QualifiedName == linkedName)

--- a/src/Models/ModelBase.cs
+++ b/src/Models/ModelBase.cs
@@ -316,25 +316,15 @@ public abstract class ModelBase<T> where T : Component
     private void SetLinkedImpl(Action<ModelBase<T>, float> set, float value)
     {
         var linked = FindLinked();
-        if (linked == null)
-        {
-            SuperController.LogError($"no link for {QualifiedName}");
-            return;
-        }
-
-        set(linked, value);
+        if (linked != null)
+            set(linked, value);
     }
 
     private void SetLinkedImpl(Action<ModelBase<T>, bool> set, bool value)
     {
         var linked = FindLinked();
-        if (linked == null)
-        {
-            SuperController.LogError($"no link for {QualifiedName}");
-            return;
-        }
-
-        set(linked, value);
+        if (linked != null)
+            set(linked, value);
     }
 
     private ModelBase<T> FindLinked()
@@ -343,6 +333,8 @@ public abstract class ModelBase<T> where T : Component
 
         if (linked != null)
             SuperController.LogError("found link " + QualifiedName + " <-> " + linked.QualifiedName);
+        else
+            SuperController.LogError($"no link for {QualifiedName}");
 
         return linked;
     }

--- a/src/Models/ModelBase.cs
+++ b/src/Models/ModelBase.cs
@@ -339,9 +339,17 @@ public abstract class ModelBase<T> where T : Component
 
     private ModelBase<T> FindLinked()
     {
-        var name = QualifiedName;
+        var linked = DoFindLinked();
 
-        SuperController.LogError("FindLinked: " + name);
+        if (linked != null)
+            SuperController.LogError("found link " + QualifiedName + " <-> " + linked.QualifiedName);
+
+        return linked;
+    }
+
+    private ModelBase<T> DoFindLinked()
+    {
+        var name = QualifiedName;
 
         var ce = (ColliderEditor)Script;
 
@@ -371,33 +379,33 @@ public abstract class ModelBase<T> where T : Component
         {
             if (ln.a == name)
             {
-                SuperController.LogError($"ln.a is {name}, checking ln.b {ln.b}");
+               // SuperController.LogError($"ln.a is {name}, checking ln.b {ln.b}");
                 foreach (var m in list)
                 {
                     if (m.QualifiedName == ln.b)
                     {
-                        SuperController.LogError($"m.QualifiedName {m.QualifiedName} matches");
+                       // SuperController.LogError($"m.QualifiedName {m.QualifiedName} matches");
                         return m as ModelBase<T>;
                     }
                     else
                     {
-                        SuperController.LogError($"m.QualifiedName {m.QualifiedName} doesn't match");
+                       // SuperController.LogError($"m.QualifiedName {m.QualifiedName} doesn't match");
                     }
                 }
             }
             else if (ln.b == name)
             {
-                SuperController.LogError($"ln.b is {name}, checking ln.a {ln.a}");
+                //SuperController.LogError($"ln.b is {name}, checking ln.a {ln.a}");
                 foreach (var m in list)
                 {
                     if (m.QualifiedName == ln.a)
                     {
-                        SuperController.LogError($"m.QualifiedName {m.QualifiedName} matches");
+                      //  SuperController.LogError($"m.QualifiedName {m.QualifiedName} matches");
                         return m as ModelBase<T>;
                     }
                     else
                     {
-                        SuperController.LogError($"m.QualifiedName {m.QualifiedName} doesn't match");
+                      //  SuperController.LogError($"m.QualifiedName {m.QualifiedName} doesn't match");
                     }
                 }
             }

--- a/src/Models/ModelBase.cs
+++ b/src/Models/ModelBase.cs
@@ -40,6 +40,18 @@ public abstract class ModelBase<T> where T : Component
 		return val + 0.025f;
 	}
 
+    public JSONStorableParam FindStorable(string name)
+    {
+        foreach (var p in _controlsStorables)
+        {
+            SuperController.LogError(p.name);
+            if (p.name == name)
+                return p;
+        }
+
+        return null;
+    }
+
     public bool Selected
     {
         get { return _selected; }
@@ -51,6 +63,11 @@ public abstract class ModelBase<T> where T : Component
                 _selected = value;
             }
         }
+    }
+
+    public virtual IModel Linked
+    {
+        get { return null; }
     }
 
     public ModelBase(MVRScript script, T component, string label)

--- a/src/Models/ModelBase.cs
+++ b/src/Models/ModelBase.cs
@@ -11,6 +11,7 @@ public abstract class ModelBase<T> where T : Component
     private readonly List<UIDynamic> _controlDynamics = new List<UIDynamic>();
     private ModelBase<T> _link = null;
     private bool _linkLookedUp = false;
+    private static bool _changingLink = false;  // avoids recursion
 
     protected readonly MVRScript Script;
 
@@ -262,8 +263,6 @@ public abstract class ModelBase<T> where T : Component
     }
 
 
-    private static bool ChangingLink = false;
-
     public virtual IModel Linked
     {
         get
@@ -285,33 +284,39 @@ public abstract class ModelBase<T> where T : Component
 
     public void SetLinked(Action<ModelBase<T>, float> set, float value)
     {
-        if (ChangingLink)
+        if (!(Script as ColliderEditor).Config.LinkColliders)
+            return;
+
+        if (_changingLink)
             return;
 
         try
         {
-            ChangingLink = true;
+            _changingLink = true;
             SetLinkedImpl(set, value);
         }
         finally
         {
-            ChangingLink = false;
+            _changingLink = false;
         }
     }
 
     public void SetLinked(Action<ModelBase<T>, bool> set, bool value)
     {
-        if (ChangingLink)
+        if (!(Script as ColliderEditor).Config.LinkColliders)
+            return;
+
+        if (_changingLink)
             return;
 
         try
         {
-            ChangingLink = true;
+            _changingLink = true;
             SetLinkedImpl(set, value);
         }
         finally
         {
-            ChangingLink = false;
+            _changingLink = false;
         }
     }
 


### PR DESCRIPTION
This links symmetrical colliders so they can be changed at the same time.

`ColliderEditor.cs` has a `_selected2` variable for the linked collider, as well a new toggle. `_selected2` is set any time `_selected` is changed by asking for its `Linked` property, which can be null for non-symmetrical colliders. The `Shown` and `Selected` properties need to be set manually because the linked collider might be from a different group, which are normally hidden. As a side effect, the controls for both colliders are shown in the UI, which I don't think is a problem.

I added the `LinkColliders` setting in `ColliderPreviewConfig`, which should really be renamed `ColliderConfig` at one point.

All the links are hardcoded in `Links.cs`, but I only did the female model. The constructor for `FemaleLinks` fills the `links_` list, which is then used to create two reciprocal dictionaries for lookups.

I only changed `AutoColliderModel.cs` and `CapsuleColliderModel.cs` to handle linked colliders. I'm not actually sure what the other models do and I don't think I've used them in VaM. I pulled all the JSON parameters into member variables because they have to be set whenever the linked collider is changed. I moved the actual code from the callback into named functions, which are passed as `Action`s to `SetLinked()` whenever a parameter changes.

The code within the various `Set*()` methods is the same as it was in the inline callback, except that it 1) sets the parameter, and 2) calls `SetLinked()`, which does the actual job of finding the linked collider and executing the `Action`. Setting the parameter is necessary to keep the UI in sync, since the controls for both colliders are visible.

`ModelBase.cs` contains the code to find the linked collider and cache it. I added the `QualifiedName` property to return the shortest unique name for colliders, since some have names like `_Collider1`. In `SetLinked()` (one for `float`, one for `bool`), I set a static `_changingLink` to avoid infinite recursion.

In `DoFindLinked()`, the collider name is looked up in the `Links` class and used to find the linked collider in the various lists in `EditablesList`.

Fixes #10.