### PR TITLE
Render XRay and normal preview simultaneously

### DIFF
--- a/src/ColliderEditor.cs
+++ b/src/ColliderEditor.cs
@@ -82,7 +82,7 @@ public class ColliderEditor : MVRScript
         {
             Config.PreviewsEnabled = value;
             foreach (var editable in EditablesList.All)
-                editable.UpdatePreviewFromConfig();
+                editable.UpdatePreviewsFromConfig();
         })
         {
             isStorable = false,
@@ -96,7 +96,7 @@ public class ColliderEditor : MVRScript
         {
             Config.XRayPreviews = value;
             foreach (var editable in EditablesList.All)
-                editable.UpdatePreviewFromConfig();
+                editable.UpdatePreviewsFromConfig();
         });
         RegisterBool(_xRayPreviewsJSON);
         var xRayPreviewsToggle = CreateToggle(_xRayPreviewsJSON);
@@ -108,7 +108,7 @@ public class ColliderEditor : MVRScript
             var alpha = value.ExponentialScale(ColliderPreviewConfig.ExponentialScaleMiddle, 1f);
             Config.PreviewsOpacity = alpha;
             foreach (var editable in EditablesList.All)
-                editable.UpdatePreviewFromConfig();
+                editable.UpdatePreviewsFromConfig();
         }, 0f, 1f);
         RegisterFloat(previewOpacityJSON);
         CreateSlider(previewOpacityJSON).label = "Preview Opacity";
@@ -119,9 +119,9 @@ public class ColliderEditor : MVRScript
             var alpha = value.ExponentialScale(ColliderPreviewConfig.ExponentialScaleMiddle, 1f);
             Config.SelectedPreviewsOpacity = alpha;
             if (_selected != null)
-                _selected.UpdatePreviewFromConfig();
+                _selected.UpdatePreviewsFromConfig();
             if (_selectedMirror != null)
-                _selectedMirror.UpdatePreviewFromConfig();
+                _selectedMirror.UpdatePreviewsFromConfig();
         }, 0f, 1f);
         RegisterFloat(selectedPreviewOpacityJSON);
         CreateSlider(selectedPreviewOpacityJSON).label = "Selected Preview Opacity";
@@ -333,7 +333,7 @@ public class ColliderEditor : MVRScript
         selected.Selected = false;
         selected.Highlighted = false;
         selected.Shown = _filteredEditables.Contains(selected);
-        selected.UpdatePreviewFromConfig();
+        selected.UpdatePreviewsFromConfig();
         selected = null;
     }
 
@@ -344,7 +344,7 @@ public class ColliderEditor : MVRScript
         selected.Shown = true;
         selected.Highlighted = true;
         selected.Selected = showUI;
-        selected.UpdatePreviewFromConfig();
+        selected.UpdatePreviewsFromConfig();
     }
 
     private void UpdateFilter()
@@ -399,7 +399,7 @@ public class ColliderEditor : MVRScript
             foreach (var e in _filteredEditables)
             {
                 e.Shown = true;
-                e.UpdatePreviewFromConfig();
+                e.UpdatePreviewsFromConfig();
             }
 
             if (_ready)
@@ -420,7 +420,7 @@ public class ColliderEditor : MVRScript
         foreach (var e in previous)
         {
             e.Shown = false;
-            e.UpdatePreviewFromConfig();
+            e.UpdatePreviewsFromConfig();
         }
 
         SelectEditable(_selected);
@@ -556,7 +556,7 @@ public class ColliderEditor : MVRScript
             AppendJson(_jsonWhenDisabled);
             foreach (var editable in EditablesList.All)
             {
-                editable.DestroyPreview();
+                editable.DestroyPreviews();
                 editable.ResetToInitial();
             }
         }
@@ -592,7 +592,7 @@ public class ColliderEditor : MVRScript
             foreach (var editable in EditablesList.All)
             {
                 if (editable.SyncOverrides())
-                    editable.SyncPreview();
+                    editable.SyncPreviews();
             }
 
             _nextUpdate = Time.time + 1f;

--- a/src/ColliderPreviewConfig.cs
+++ b/src/ColliderPreviewConfig.cs
@@ -4,13 +4,15 @@ public class ColliderPreviewConfig
 
     public const bool DefaultPreviewsEnabled = false;
     public const bool DefaultXRayPreviews = true;
-    public const float DefaultPreviewsOpacity = 0.2f;
-    public const float DefaultSelectedPreviewOpacity = 0.7f;
+    public const float DefaultPreviewsOpacity = 0.5f;
+    public const float DefaultSelectedPreviewOpacity = 1.0f;
+    public const float DefaultRelativeXRayOpacity = 0.5f;
     public const bool DefaultSyncSymmetry = false;
 
     public bool PreviewsEnabled { get; set; } = DefaultPreviewsEnabled;
     public bool XRayPreviews { get; set; } = DefaultXRayPreviews;
     public bool SyncSymmetry { get; set; } = DefaultSyncSymmetry;
-    public float PreviewsOpacity {get;set;} = DefaultPreviewsOpacity.ExponentialScale(ExponentialScaleMiddle, 1f);
-    public float SelectedPreviewsOpacity {get;set;} = DefaultSelectedPreviewOpacity.ExponentialScale(ExponentialScaleMiddle, 1f);
+    public float PreviewsOpacity { get; set; } = DefaultPreviewsOpacity.ExponentialScale(ExponentialScaleMiddle, 1f);
+    public float SelectedPreviewsOpacity { get; set; } = DefaultSelectedPreviewOpacity.ExponentialScale(ExponentialScaleMiddle, 1f);
+    public float RelativeXRayOpacity { get; set; } = DefaultRelativeXRayOpacity;
 }

--- a/src/Models/AutoColliderModel.cs
+++ b/src/Models/AutoColliderModel.cs
@@ -289,7 +289,7 @@ public class AutoColliderModel : ColliderContainerModelBase<AutoCollider>, IMode
         AutoCollider.resizeTrigger = AutoCollider.ResizeTrigger.Always;
         AutoCollider.AutoColliderSizeSet(true);
         AutoCollider.resizeTrigger = previousResizeTrigger;
-        SyncPreview();
+        SyncPreviews();
     }
 
     public void ReapplyMultiplier()

--- a/src/Models/BoxColliderModel.cs
+++ b/src/Models/BoxColliderModel.cs
@@ -34,12 +34,18 @@ public class BoxColliderModel : ColliderModel<BoxCollider>
 
     protected override GameObject DoCreatePreview() => GameObject.CreatePrimitive(PrimitiveType.Cube);
 
-    public override void SyncPreview()
+    public override void SyncPreviews()
     {
-        if (Preview == null) return;
+        SyncPreview(Preview);
+        SyncPreview(XRayPreview);
+    }
 
-        Preview.transform.localScale = Collider.size;
-        Preview.transform.localPosition = Collider.center;
+    private void SyncPreview(GameObject preview)
+    {
+        if (preview == null) return;
+
+        preview.transform.localScale = Collider.size;
+        preview.transform.localPosition = Collider.center;
     }
 
     protected override void DoLoadJson(JSONClass jsonClass)
@@ -78,7 +84,7 @@ public class BoxColliderModel : ColliderModel<BoxCollider>
             size.x = value;
             Collider.size = _size = size;
             SetModified();
-            SyncPreview();
+            SyncPreviews();
         }, -0.25f, 0.25f, false)).WithDefault(_initialSize.x), "Size.X"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("sizeY", Collider.size.y, value =>
@@ -87,7 +93,7 @@ public class BoxColliderModel : ColliderModel<BoxCollider>
             size.y = value;
             Collider.size = _size = size;
             SetModified();
-            SyncPreview();
+            SyncPreviews();
         }, -0.25f, 0.25f, false)).WithDefault(_initialSize.y), "Size.Y"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("sizeZ", Collider.size.z, value =>
@@ -96,7 +102,7 @@ public class BoxColliderModel : ColliderModel<BoxCollider>
             size.z = value;
             Collider.size = _size = size;
             SetModified();
-            SyncPreview();
+            SyncPreviews();
         }, -0.25f, 0.25f, false)).WithDefault(_initialSize.z), "Size.Z"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerX", Collider.center.x, value =>
@@ -105,7 +111,7 @@ public class BoxColliderModel : ColliderModel<BoxCollider>
             center.x = value;
             Collider.center = _center = center;
             SetModified();
-            SyncPreview();
+            SyncPreviews();
         }, MakeMinPosition(Collider.center.x), MakeMaxPosition(Collider.center.x), false)).WithDefault(_initialCenter.x), "Center.X"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerY", Collider.center.y, value =>
@@ -114,7 +120,7 @@ public class BoxColliderModel : ColliderModel<BoxCollider>
             center.y = value;
             Collider.center = _center = center;
             SetModified();
-            SyncPreview();
+            SyncPreviews();
         }, MakeMinPosition(Collider.center.y), MakeMaxPosition(Collider.center.y), false)).WithDefault(_initialCenter.y), "Center.Y"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerZ", Collider.center.z, value =>
@@ -123,7 +129,7 @@ public class BoxColliderModel : ColliderModel<BoxCollider>
             center.z = value;
             Collider.center = _center = center;
             SetModified();
-            SyncPreview();
+            SyncPreviews();
         }, MakeMinPosition(Collider.center.z), MakeMaxPosition(Collider.center.z), false)).WithDefault(_initialCenter.z), "Center.Z"));
     }
 }

--- a/src/Models/CapsuleColliderModel.cs
+++ b/src/Models/CapsuleColliderModel.cs
@@ -107,7 +107,7 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
         Collider.radius = _radius = value;
         _gpu?.UpdateData();
         SetModified();
-        SyncPreview();
+        SyncPreviews();
         SetMirror<CapsuleColliderModel>(m => m.SetRadius(value));
     }
 
@@ -117,7 +117,7 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
         Collider.height = _height = value;
         _gpu?.UpdateData();
         SetModified();
-        SyncPreview();
+        SyncPreviews();
         SetMirror<CapsuleColliderModel>(m => m.SetHeight(value));
     }
 
@@ -129,7 +129,7 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
         Collider.center = _center = center;
         _gpu?.UpdateData();
         SetModified();
-        SyncPreview();
+        SyncPreviews();
         SetMirror<CapsuleColliderModel>(m => m.SetCenterX(-value));
     }
 
@@ -141,7 +141,7 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
         Collider.center = _center = center;
         _gpu?.UpdateData();
         SetModified();
-        SyncPreview();
+        SyncPreviews();
         SetMirror<CapsuleColliderModel>(m => m.SetCenterY(value));
     }
 
@@ -153,7 +153,7 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
         Collider.center = _center = center;
         _gpu?.UpdateData();
         SetModified();
-        SyncPreview();
+        SyncPreviews();
         SetMirror<CapsuleColliderModel>(m => m.SetCenterZ(value));
     }
 
@@ -218,17 +218,23 @@ public class CapsuleColliderModel : ColliderModel<CapsuleCollider>
 
     protected override GameObject DoCreatePreview() => GameObject.CreatePrimitive(PrimitiveType.Capsule);
 
-    public override void SyncPreview()
+    public override void SyncPreviews()
     {
-        if (Preview == null) return;
+        SyncPreview(Preview);
+        SyncPreview(XRayPreview);
+    }
+
+    private void SyncPreview(GameObject preview)
+    {
+        if (preview == null) return;
 
         float size = Collider.radius * 2;
         float height = Collider.height / 2;
-        Preview.transform.localScale = new Vector3(size, height, size);
+        preview.transform.localScale = new Vector3(size, height, size);
         if (Collider.direction == 0)
-            Preview.transform.localRotation = Quaternion.AngleAxis(90, Vector3.forward);
+            preview.transform.localRotation = Quaternion.AngleAxis(90, Vector3.forward);
         else if (Collider.direction == 2)
-            Preview.transform.localRotation = Quaternion.AngleAxis(90, Vector3.right);
-        Preview.transform.localPosition = Collider.center;
+            preview.transform.localRotation = Quaternion.AngleAxis(90, Vector3.right);
+        preview.transform.localPosition = Collider.center;
     }
 }

--- a/src/Models/ColliderContainerModelBase.cs
+++ b/src/Models/ColliderContainerModelBase.cs
@@ -36,24 +36,24 @@ public abstract class ColliderContainerModelBase<T> : ModelBase<T> where T : Com
             collider.SetHighlighted(value);
     }
 
-    public override void SyncPreview()
+    public override void SyncPreviews()
     {
         if (!OwnsColliders) return;
         foreach (var colliderModel in GetColliders())
-            colliderModel.SyncPreview();
+            colliderModel.SyncPreviews();
     }
 
-    public virtual void UpdatePreviewFromConfig()
+    public virtual void UpdatePreviewsFromConfig()
     {
         if (!OwnsColliders) return;
         foreach (var colliderModel in GetColliders())
-            colliderModel.UpdatePreviewFromConfig();
+            colliderModel.UpdatePreviewsFromConfig();
     }
 
-    public void DestroyPreview()
+    public void DestroyPreviews()
     {
         foreach (var colliderModel in GetColliders())
-            colliderModel.DestroyPreview();
+            colliderModel.DestroyPreviews();
     }
 
     public abstract IEnumerable<ColliderModel> GetColliders();

--- a/src/Models/ColliderModel.cs
+++ b/src/Models/ColliderModel.cs
@@ -87,8 +87,8 @@ public abstract class ColliderModel : ModelBase<Collider>, IModel
             UpdateXRayPreviewFromConfig();
 
             SyncPreviews();
-            RefreshHighlighted(Preview);
-            RefreshHighlighted(XRayPreview);
+            RefreshHighlightedPreview();
+            RefreshHighlightedXRayPreview();
         }
         else
         {
@@ -111,13 +111,13 @@ public abstract class ColliderModel : ModelBase<Collider>, IModel
             if (!_highlighted)
             {
                 var color = previewRenderer.material.color;
-                color.a = _config.PreviewsOpacity;
+                color.a = _config.RelativeXRayOpacity * _config.PreviewsOpacity;
                 previewRenderer.material.color = color;
             }
             else
             {
                 var color = previewRenderer.material.color;
-                color.a = _config.SelectedPreviewsOpacity;
+                color.a = _config.RelativeXRayOpacity * _config.SelectedPreviewsOpacity;
                 previewRenderer.material.color = color;
                 previewRenderer.enabled = false;
                 previewRenderer.enabled = true;
@@ -217,17 +217,29 @@ public abstract class ColliderModel : ModelBase<Collider>, IModel
         if (_highlighted == value) return;
 
         _highlighted = value;
-        RefreshHighlighted(Preview);
-        RefreshHighlighted(XRayPreview);
+        RefreshHighlightedPreview();
+        RefreshHighlightedXRayPreview();
     }
 
-    protected void RefreshHighlighted(GameObject preview)
+    protected void RefreshHighlightedPreview()
     {
-        if (preview != null)
+        if (Preview != null)
         {
-            var previewRenderer = preview.GetComponent<Renderer>();
+            var previewRenderer = Preview.GetComponent<Renderer>();
             var color = previewRenderer.material.color;
             color.a = _highlighted ? _config.SelectedPreviewsOpacity : _config.PreviewsOpacity;
+            previewRenderer.material.color = color;
+        }
+    }
+
+    protected void RefreshHighlightedXRayPreview()
+    {
+        if (XRayPreview != null)
+        {
+            var previewRenderer = XRayPreview.GetComponent<Renderer>();
+            var color = previewRenderer.material.color;
+            var alpha = _highlighted ? _config.SelectedPreviewsOpacity : _config.PreviewsOpacity;
+            color.a = _config.RelativeXRayOpacity * alpha;
             previewRenderer.material.color = color;
         }
     }

--- a/src/Models/IModel.cs
+++ b/src/Models/IModel.cs
@@ -13,9 +13,9 @@ public interface IModel
     IModel MirrorModel { get; }
     bool SyncWithMirror { get; set; }
 
-    void UpdatePreviewFromConfig();
-    void SyncPreview();
-    void DestroyPreview();
+    void UpdatePreviewsFromConfig();
+    void SyncPreviews();
+    void DestroyPreviews();
     void ResetToInitial();
     bool SyncOverrides();
 

--- a/src/Models/ModelBase.cs
+++ b/src/Models/ModelBase.cs
@@ -94,7 +94,7 @@ public abstract class ModelBase<T> where T : Component
             DestroyControls();
     }
 
-    public abstract void SyncPreview();
+    public abstract void SyncPreviews();
 
     public void SetModified()
     {

--- a/src/Models/SphereColliderModel.cs
+++ b/src/Models/SphereColliderModel.cs
@@ -63,7 +63,7 @@ public class SphereColliderModel : ColliderModel<SphereCollider>
         {
             Collider.radius = _radius = value;
             SetModified();
-            SyncPreview();
+            SyncPreviews();
         }, 0f, _initialRadius * 4f, false)).WithDefault(_initialRadius), "Radius"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerX", Collider.center.x, value =>
@@ -72,7 +72,7 @@ public class SphereColliderModel : ColliderModel<SphereCollider>
             center.x = value;
             Collider.center = _center = center;
             SetModified();
-            SyncPreview();
+            SyncPreviews();
         }, MakeMinPosition(Collider.center.x), MakeMaxPosition(Collider.center.x), false)).WithDefault(_initialCenter.x), "Center.X"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerY", Collider.center.y, value =>
@@ -81,7 +81,7 @@ public class SphereColliderModel : ColliderModel<SphereCollider>
             center.y = value;
             Collider.center = _center = center;
             SetModified();
-            SyncPreview();
+            SyncPreviews();
         }, MakeMinPosition(Collider.center.y), MakeMaxPosition(Collider.center.y), false)).WithDefault(_initialCenter.y), "Center.Y"));
 
         RegisterControl(Script.CreateFloatSlider(RegisterStorable(new JSONStorableFloat("centerZ", Collider.center.z, value =>
@@ -90,7 +90,7 @@ public class SphereColliderModel : ColliderModel<SphereCollider>
             center.z = value;
             Collider.center = _center = center;
             SetModified();
-            SyncPreview();
+            SyncPreviews();
         }, MakeMinPosition(Collider.center.z), MakeMaxPosition(Collider.center.z), false)).WithDefault(_initialCenter.z), "Center.Z"));
 
         if (_gpu != null)
@@ -111,12 +111,18 @@ public class SphereColliderModel : ColliderModel<SphereCollider>
 
     protected override GameObject DoCreatePreview() => GameObject.CreatePrimitive(PrimitiveType.Sphere);
 
-    public override void SyncPreview()
+    public override void SyncPreviews()
     {
-        if (Preview == null) return;
+        SyncPreview(Preview);
+        SyncPreview(XRayPreview);
+    }
 
-        Preview.transform.localScale = Vector3.one * (Collider.radius * 2);
-        Preview.transform.localPosition = Collider.center;
+    private void SyncPreview(GameObject preview)
+    {
+        if (preview == null) return;
+
+        preview.transform.localScale = Vector3.one * (Collider.radius * 2);
+        preview.transform.localPosition = Collider.center;
     }
 
     protected override void DoLoadJson(JSONClass jsonClass)


### PR DESCRIPTION
The XRay preview and the normal preview are rendered simultaneously to more easily see which part of the collider is sticking out and which part is under the skin.

The XRay preview is rendered at half the opacity. I didn't add a slider for configuring that, I think half the opacity looks good. I also increased the default slider values:

- Preview Opacity from 0.2 to 0.5 to compensate for XRay preview being always half the opacity
- Selected Preview Opacity from 0.7 to 1.0, the selected collider now looks opaque by default where it is sticking out of the skin, which makes it easily noticeable

There's currently no way to render _just_ the XRay preview. That's wouldn't really informative in my opinion and is not needed, but it could be added back if needed. Reducing the opacity will make the normal preview see-through as well.

